### PR TITLE
Polish room view voting layout and readability

### DIFF
--- a/frontend/src/components/VoteDistribution.vue
+++ b/frontend/src/components/VoteDistribution.vue
@@ -39,11 +39,10 @@ const median = computed(() => {
 
 const n = computed(() => numericVotes.value.length);
 
-function bandFor(value: string): "green" | "amber" | "red" | "violet" {
-  if (value === "?" || value === "1" || value === "2") return "green";
-  if (value === "3" || value === "5") return "amber";
-  if (value === "8" || value === "13") return "red";
-  return "violet";
+const chartColors = ["green", "amber", "red", "violet", "blue", "pink"] as const;
+
+function chartColorFor(index: number): (typeof chartColors)[number] {
+  return chartColors[index % chartColors.length];
 }
 </script>
 
@@ -59,12 +58,12 @@ function bandFor(value: string): "green" | "amber" | "red" | "violet" {
     </header>
 
     <div v-if="buckets.length" class="chart">
-      <div v-for="b in buckets" :key="b.value" class="col">
+      <div v-for="(b, index) in buckets" :key="b.value" class="col">
         <span class="count">{{ b.count }}</span>
         <div class="bar-track">
           <div
             class="bar"
-            :class="`band-${bandFor(b.value)}`"
+            :class="`bar-${chartColorFor(index)}`"
             :style="{ height: `${(b.count / maxCount) * 100}%` }"
           />
         </div>
@@ -151,17 +150,23 @@ function bandFor(value: string): "green" | "amber" | "red" | "violet" {
       background: var(--p-emerald-400);
       transition: height 0.3s ease;
 
-      &.band-green {
+      &.bar-green {
         background: var(--p-emerald-400);
       }
-      &.band-amber {
+      &.bar-amber {
         background: var(--p-amber-400);
       }
-      &.band-red {
+      &.bar-red {
         background: var(--p-red-400);
       }
-      &.band-violet {
+      &.bar-violet {
         background: var(--p-violet-400);
+      }
+      &.bar-blue {
+        background: var(--p-blue-400);
+      }
+      &.bar-pink {
+        background: var(--p-pink-400);
       }
     }
 

--- a/frontend/src/components/VoteDistribution.vue
+++ b/frontend/src/components/VoteDistribution.vue
@@ -61,11 +61,13 @@ function bandFor(value: string): "green" | "amber" | "red" | "violet" {
     <div v-if="buckets.length" class="chart">
       <div v-for="b in buckets" :key="b.value" class="col">
         <span class="count">{{ b.count }}</span>
-        <div
-          class="bar"
-          :class="`band-${bandFor(b.value)}`"
-          :style="{ height: `${(b.count / maxCount) * 100}%` }"
-        />
+        <div class="bar-track">
+          <div
+            class="bar"
+            :class="`band-${bandFor(b.value)}`"
+            :style="{ height: `${(b.count / maxCount) * 100}%` }"
+          />
+        </div>
         <span class="label">{{ b.value }}</span>
       </div>
     </div>
@@ -122,15 +124,24 @@ function bandFor(value: string): "green" | "amber" | "red" | "violet" {
   .col {
     flex: 1 1 0;
     min-width: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    align-items: stretch;
     gap: 0.25rem;
     height: 100%;
 
     .count {
+      justify-self: center;
       font-size: 0.75rem;
       color: var(--p-text-muted-color);
+    }
+
+    .bar-track {
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      display: flex;
+      align-items: flex-end;
     }
 
     .bar {
@@ -155,6 +166,7 @@ function bandFor(value: string): "green" | "amber" | "red" | "violet" {
     }
 
     .label {
+      justify-self: center;
       font-size: 0.75rem;
       font-weight: 700;
       color: var(--p-text-color);

--- a/frontend/src/components/VotingProgress.vue
+++ b/frontend/src/components/VotingProgress.vue
@@ -1,15 +1,24 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { getAvatarColor, getInitials, paletteVar } from "@/modules/avatarColor";
 import type { RoomMember } from "@/modules/roomMembers";
 
-defineProps<{ members: RoomMember[] }>();
+const props = defineProps<{ members: RoomMember[] }>();
+
+const sortedMembers = computed(() =>
+  [...props.members].sort((a, b) => {
+    if (a.point != null && b.point == null) return -1;
+    if (a.point == null && b.point != null) return 1;
+    return a.name.localeCompare(b.name);
+  }),
+);
 </script>
 
 <template>
   <aside class="voting-progress surface-panel">
     <h3 class="title">Voting in progress</h3>
     <TransitionGroup tag="ul" name="vp-list">
-      <li v-for="m in members" :key="m.name" :class="{ ready: m.point != null }">
+      <li v-for="m in sortedMembers" :key="m.name" :class="{ ready: m.point != null }">
         <span class="dot" :class="{ ready: m.point != null }" />
         <span class="avatar" :style="{ background: paletteVar[getAvatarColor(m.name)] }">
           {{ getInitials(m.name) }}

--- a/frontend/src/modules/avatarColor.ts
+++ b/frontend/src/modules/avatarColor.ts
@@ -10,6 +10,12 @@ function hash(input: string): number {
   return Math.abs(h);
 }
 
+function getGraphemes(input: string): string[] {
+  return [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(input)].map(
+    ({ segment }) => segment,
+  );
+}
+
 export function getAvatarColor(username: string): AvatarPalette {
   if (!username) return "emerald";
   return palette[hash(username) % palette.length];
@@ -21,10 +27,13 @@ export function getInitials(username: string): string {
     .trim()
     .split(/[\s_-]+/)
     .filter(Boolean);
-  if (parts.length >= 2) {
-    return (parts[0][0] + parts[1][0]).toUpperCase();
+  const wordInitials = parts.map((part) => part.match(/[\p{L}\p{N}]/u)?.[0]).filter(Boolean);
+  if (wordInitials.length >= 2) {
+    return wordInitials.slice(0, 2).join("").toUpperCase();
   }
-  return username.slice(0, 2).toUpperCase();
+  const letters = username.match(/[\p{L}\p{N}]/gu);
+  if (letters?.length) return letters.slice(0, 2).join("").toUpperCase();
+  return getGraphemes(username.trim())[0] ?? "??";
 }
 
 export const paletteVar: Record<AvatarPalette, string> = {

--- a/frontend/src/views/RoomView.vue
+++ b/frontend/src/views/RoomView.vue
@@ -486,9 +486,13 @@ main {
   }
 
   .grid {
+    flex: 1 1 auto;
+    min-height: 0;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    align-content: center;
+    align-items: center;
     gap: 0.4rem;
 
     @media (min-width: 500px) {


### PR DESCRIPTION
## Summary
- Center participant cards within the room board and keep the voting progress rail sorted by readiness.
- Fix vote distribution bars so they grow from a shared baseline and alternate colors for adjacent buckets.
- Handle emoji safely in avatar initials while preserving emoji-only display names.

## Validation
- bun run type-check
- bun run lint