### PR TITLE
feat: add live room reactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@
 - Frontend: `bun run dev`, `bun run build`, `bun run type-check`, `bun run lint` (oxlint), `bun run fmt` (oxfmt)
 - Backend: `bun --watch src/index.ts` for local dev, `bun test` for coverage-enabled tests
 
+## Frontend Patterns
+
+- `frontend/src/composables/useRoomSession.ts` is the room orchestrator: it owns the WebSocket connection, the single message `switch`, and session-wide state. Do not add a second message handler.
+- Feature-specific UI state goes in its own composable under `frontend/src/composables/`, instantiated by the session (template: `useReactions.ts`). Feature composables receive session state as refs (e.g. `username`, `connectionStatus`), may import senders from `@/modules/socket` directly, and expose plain methods for the session's message switch to call — never forward raw server messages into them; the switch stays the one place that maps messages to behavior.
+- A feature composable that owns timers or other cleanup exposes a `dispose()` for `teardownRoomSession` to call. The session re-exports the feature's view-facing surface from its own return object so views keep a single `useRoomSession(...)` entry point.
+
 ## Repo Gotchas
 
 - Frontend env files come from `frontend/.env.sample`; create `frontend/.env.development` and `frontend/.env.production` from it.

--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ Most of these are additive to the `ClientMessage`/`ServerMessage` unions in
 ### Tier 3 — Consider, but watch the "no fluff" line
 
 - **Light-mode toggle** — The app currently forces dark mode (`modules/darkMode.ts`).
-- **Emoji reactions** — Lightweight remote-team feel; risks becoming the fluff we
-  market against. No chat.
 - **Opt-in sound/notification** on reveal or "your turn".
 
 ### Explicitly out of scope

--- a/backend/src/__tests__/reactions.test.ts
+++ b/backend/src/__tests__/reactions.test.ts
@@ -1,0 +1,56 @@
+import type { ServerWebSocket } from "bun";
+import { describe, expect, test } from "bun:test";
+import { isReactionEmoji, reactionEmojis } from "@shared/types";
+import type { WebSocketData } from "@shared/types";
+import { REACTION_REFILL_INTERVAL_MS, ReactionRateLimiter } from "../reactionRateLimiter";
+
+describe("room reactions", () => {
+  test("the six picker reactions are accepted", () => {
+    expect(reactionEmojis).toEqual(["👍", "🎉", "🤔", "👀", "⏳", "☕"]);
+    reactionEmojis.forEach((emoji) => expect(isReactionEmoji(emoji)).toBe(true));
+  });
+
+  test("arbitrary strings and non-strings are rejected", () => {
+    expect(isReactionEmoji("🔥")).toBe(false);
+    expect(isReactionEmoji("👍👍")).toBe(false);
+    expect(isReactionEmoji(undefined)).toBe(false);
+  });
+
+  test("allows a burst of three reactions, then returns the refill delay", () => {
+    let now = 0;
+    const limiter = new ReactionRateLimiter(() => now);
+    const socket = {} as ServerWebSocket<WebSocketData>;
+
+    expect(limiter.consume(socket).allowed).toBe(true);
+    expect(limiter.consume(socket).allowed).toBe(true);
+    expect(limiter.consume(socket).allowed).toBe(true);
+    expect(limiter.consume(socket)).toEqual({
+      allowed: false,
+      retryAfterMs: REACTION_REFILL_INTERVAL_MS,
+    });
+
+    now = REACTION_REFILL_INTERVAL_MS / 2;
+    expect(limiter.consume(socket)).toEqual({
+      allowed: false,
+      retryAfterMs: REACTION_REFILL_INTERVAL_MS / 2,
+    });
+
+    now = REACTION_REFILL_INTERVAL_MS;
+    expect(limiter.consume(socket)).toEqual({ allowed: true, retryAfterMs: 0 });
+  });
+
+  test("tracks each WebSocket independently and caps refilled tokens", () => {
+    let now = 0;
+    const limiter = new ReactionRateLimiter(() => now);
+    const firstSocket = {} as ServerWebSocket<WebSocketData>;
+    const secondSocket = {} as ServerWebSocket<WebSocketData>;
+
+    for (let i = 0; i < 3; i++) expect(limiter.consume(firstSocket).allowed).toBe(true);
+    expect(limiter.consume(firstSocket).allowed).toBe(false);
+    expect(limiter.consume(secondSocket).allowed).toBe(true);
+
+    now = REACTION_REFILL_INTERVAL_MS * 10;
+    for (let i = 0; i < 3; i++) expect(limiter.consume(firstSocket).allowed).toBe(true);
+    expect(limiter.consume(firstSocket).allowed).toBe(false);
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,13 +1,15 @@
-import { isDeckId, type WebSocketData } from "@shared/types";
+import { isDeckId, isReactionEmoji, type WebSocketData } from "@shared/types";
 import { InMemoryRoomManager } from "./roomManager";
 import { MessageHandler } from "./messageHandler";
 import { ConnectionManager } from "./connectionManager";
 import { DisconnectManager } from "./disconnectManager";
 import { logger } from "./logger";
+import { ReactionRateLimiter } from "./reactionRateLimiter";
 
 const connectionManager = new ConnectionManager();
 const roomManager = new InMemoryRoomManager();
 const disconnectManager = new DisconnectManager();
+const reactionRateLimiter = new ReactionRateLimiter();
 
 const ErrorCodes = {
   Unknown: 4000,
@@ -120,6 +122,34 @@ const server = Bun.serve<WebSocketData, undefined>({
               MessageHandler.createUserVotedMessage(roomId, username, roomManager),
             );
             break;
+
+          case "sendReaction": {
+            const emoji = msg.data?.emoji;
+            if (!isReactionEmoji(emoji)) throw new Error("Invalid reaction");
+
+            const rateLimit = reactionRateLimiter.consume(ws);
+            if (!rateLimit.allowed) {
+              ws.send(
+                MessageHandler.createMessage({
+                  type: "reactionRateLimited",
+                  data: { retryAfterMs: rateLimit.retryAfterMs },
+                }),
+              );
+              break;
+            }
+
+            // Reactions are live-only: broadcast directly without adding
+            // anything to the room snapshot. `server.publish` includes the
+            // sender so every client follows the same receive path.
+            server.publish(
+              roomId,
+              MessageHandler.createMessage({
+                type: "reaction",
+                data: { username, emoji },
+              }),
+            );
+            break;
+          }
 
           case "revealVotes":
             roomManager.setVoteVisibility(roomId, username, true);

--- a/backend/src/reactionRateLimiter.ts
+++ b/backend/src/reactionRateLimiter.ts
@@ -1,0 +1,51 @@
+import type { ServerWebSocket } from "bun";
+import type { WebSocketData } from "@shared/types";
+
+export const REACTION_BUCKET_CAPACITY = 3;
+export const REACTION_REFILL_INTERVAL_MS = 1500;
+
+type ReactionBucket = {
+  tokens: number;
+  lastRefillAt: number;
+};
+
+export type ReactionRateLimitResult =
+  | { allowed: true; retryAfterMs: 0 }
+  | { allowed: false; retryAfterMs: number };
+
+/**
+ * Per-connection token bucket. Weak keys let closed sockets and their
+ * buckets be garbage-collected without explicit room or disconnect state.
+ */
+export class ReactionRateLimiter {
+  private readonly buckets = new WeakMap<ServerWebSocket<WebSocketData>, ReactionBucket>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  consume(socket: ServerWebSocket<WebSocketData>): ReactionRateLimitResult {
+    const now = this.now();
+    const bucket = this.buckets.get(socket) ?? {
+      tokens: REACTION_BUCKET_CAPACITY,
+      lastRefillAt: now,
+    };
+    const effectiveNow = Math.max(now, bucket.lastRefillAt);
+    const elapsed = effectiveNow - bucket.lastRefillAt;
+
+    bucket.tokens = Math.min(
+      REACTION_BUCKET_CAPACITY,
+      bucket.tokens + elapsed / REACTION_REFILL_INTERVAL_MS,
+    );
+    bucket.lastRefillAt = effectiveNow;
+    this.buckets.set(socket, bucket);
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return { allowed: true, retryAfterMs: 0 };
+    }
+
+    return {
+      allowed: false,
+      retryAfterMs: Math.ceil((1 - bucket.tokens) * REACTION_REFILL_INTERVAL_MS),
+    };
+  }
+}

--- a/frontend/src/assets/base.scss
+++ b/frontend/src/assets/base.scss
@@ -54,6 +54,15 @@ body {
   border-radius: 1rem;
 }
 
+.panel-title {
+  margin: 0;
+  color: var(--p-text-muted-color);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/frontend/src/components/ReactionBar.vue
+++ b/frontend/src/components/ReactionBar.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { reactionEmojis, type ReactionEmoji } from "@shared/types";
+
+withDefaults(defineProps<{ disabled?: boolean; rateLimited?: boolean }>(), {
+  disabled: false,
+  rateLimited: false,
+});
+
+const emit = defineEmits<{
+  react: [emoji: ReactionEmoji];
+}>();
+
+const labels: Record<ReactionEmoji, string> = {
+  "👍": "thumbs up",
+  "🎉": "celebrate",
+  "🤔": "thinking",
+  "👀": "eyes",
+  "⏳": "hourglass",
+  "☕": "coffee break",
+};
+</script>
+
+<template>
+  <section class="reaction-bar surface-panel" aria-label="Reactions">
+    <div class="heading">
+      <h3 class="panel-title">Reactions</h3>
+      <span class="rate-limit-status" role="status" aria-live="polite" aria-atomic="true">
+        {{ rateLimited ? "Take a beat…" : "" }}
+      </span>
+    </div>
+    <div class="picker">
+      <button
+        v-for="emoji in reactionEmojis"
+        :key="emoji"
+        type="button"
+        :aria-label="`React with ${labels[emoji]}`"
+        :title="labels[emoji]"
+        :disabled="disabled"
+        @click="emit('react', emoji)"
+      >
+        <span aria-hidden="true">{{ emoji }}</span>
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped lang="scss">
+.reaction-bar {
+  padding: 1rem;
+
+  .heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .rate-limit-status {
+    min-height: 1em;
+    color: var(--p-amber-400);
+    font-size: 0.7rem;
+    line-height: 1;
+    white-space: nowrap;
+  }
+}
+
+.picker {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.35rem;
+
+  button {
+    display: grid;
+    min-width: 0;
+    min-height: 2.5rem;
+    place-items: center;
+    padding: 0;
+    border: 1px solid var(--p-content-border-color);
+    border-radius: 0.65rem;
+    background: color-mix(in srgb, var(--p-content-background) 72%, white 4%);
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    font-size: 1.15rem;
+    line-height: 1;
+    touch-action: manipulation;
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease,
+      transform 150ms ease;
+
+    &:hover:not(:disabled),
+    &:focus-visible {
+      border-color: color-mix(in srgb, var(--p-primary-color) 70%, white);
+      background: color-mix(in srgb, var(--p-primary-color) 14%, var(--p-content-background));
+      transform: translateY(-2px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--p-primary-color);
+      outline-offset: 2px;
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(0) scale(0.92);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+    }
+  }
+}
+</style>

--- a/frontend/src/components/ReactionFeed.vue
+++ b/frontend/src/components/ReactionFeed.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import type { RoomReaction } from "@/composables/useReactions";
+
+defineProps<{ items: RoomReaction[] }>();
+</script>
+
+<template>
+  <section class="reaction-feed surface-panel" aria-label="Recent reactions">
+    <TransitionGroup tag="ol" name="reaction-feed" aria-live="polite" aria-relevant="additions">
+      <li v-for="item in items" :key="item.id">
+        <span class="emoji" aria-hidden="true">{{ item.emoji }}</span>
+        <span class="message"
+          ><strong>{{ item.who }}</strong> reacted</span
+        >
+      </li>
+    </TransitionGroup>
+  </section>
+</template>
+
+<style scoped lang="scss">
+.reaction-feed {
+  padding: 0.75rem 1rem;
+  overflow: hidden;
+
+  ol {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-width: 0;
+    font-size: 0.8rem;
+  }
+
+  .emoji {
+    flex: 0 0 auto;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .message {
+    overflow: hidden;
+    color: var(--p-text-muted-color);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  strong {
+    color: var(--p-text-color);
+    font-weight: 600;
+  }
+}
+
+.reaction-feed-enter-active,
+.reaction-feed-leave-active {
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease;
+}
+
+.reaction-feed-enter-from {
+  opacity: 0;
+  transform: translateY(-0.35rem);
+}
+
+.reaction-feed-leave-to {
+  opacity: 0;
+  transform: translateX(0.5rem);
+}
+</style>

--- a/frontend/src/components/VoteDistribution.vue
+++ b/frontend/src/components/VoteDistribution.vue
@@ -74,7 +74,7 @@ const cardColors = computed(() => {
 <template>
   <aside class="distribution surface-panel">
     <header>
-      <h3 class="title">Distribution</h3>
+      <h3 class="panel-title">Distribution</h3>
       <div class="stats">
         <span><em>avg</em> {{ avg ?? "—" }}</span>
         <span><em>med</em> {{ median ?? "—" }}</span>
@@ -114,15 +114,6 @@ const cardColors = computed(() => {
     align-items: baseline;
     gap: 0.5rem;
     flex-wrap: wrap;
-  }
-
-  .title {
-    margin: 0;
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--p-text-muted-color);
   }
 
   .stats {

--- a/frontend/src/components/VotingProgress.vue
+++ b/frontend/src/components/VotingProgress.vue
@@ -16,7 +16,7 @@ const sortedMembers = computed(() =>
 
 <template>
   <aside class="voting-progress surface-panel">
-    <h3 class="title">Voting in progress</h3>
+    <h3 class="title panel-title">Voting in progress</h3>
     <TransitionGroup tag="ul" name="vp-list">
       <li v-for="m in sortedMembers" :key="m.name" :class="{ ready: m.point != null }">
         <span class="dot" :class="{ ready: m.point != null }" />
@@ -45,12 +45,7 @@ const sortedMembers = computed(() =>
   padding: 1.25rem;
 
   .title {
-    margin: 0 0 0.75rem;
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--p-text-muted-color);
+    margin-bottom: 0.75rem;
   }
 
   ul {

--- a/frontend/src/composables/useReactions.ts
+++ b/frontend/src/composables/useReactions.ts
@@ -1,0 +1,111 @@
+import { computed, ref, type Ref } from "vue";
+import type { ReactionEmoji } from "@shared/types";
+import { sendReaction as sendReactionMessage, type ConnectionStatus } from "@/modules/socket";
+
+export type RoomReaction = {
+  id: number;
+  emoji: ReactionEmoji;
+  who: string;
+  x: number;
+};
+
+const BURST_LIFETIME_MS = 1800;
+const FEED_LIFETIME_MS = 5000;
+const MAX_FEED_ITEMS = 4;
+const MAX_VISIBLE_BURSTS = 12;
+
+/**
+ * Feature composable hanging off the room session (the template for the
+ * pattern — see AGENTS.md). It owns all reaction UI state and receives
+ * session state as refs; the session's message switch stays the single
+ * mapping from server messages to behavior and calls the plain methods
+ * exposed here (`show`, `applyRateLimit`, `clearRateLimit`, `dispose`)
+ * rather than forwarding raw messages in.
+ */
+export function useReactions(session: {
+  username: Ref<string>;
+  connectionStatus: Ref<ConnectionStatus>;
+}) {
+  const reactionBursts = ref<RoomReaction[]>([]);
+  const reactionFeed = ref<RoomReaction[]>([]);
+  const reactionsRateLimited = ref(false);
+  const timers = new Set<ReturnType<typeof setTimeout>>();
+  let rateLimitTimer: ReturnType<typeof setTimeout> | undefined;
+  let nextReactionId = 0;
+
+  const canReact = computed(
+    () => session.connectionStatus.value === "connected" && !reactionsRateLimited.value,
+  );
+
+  function scheduleCleanup(callback: () => void, delay: number) {
+    const timer = setTimeout(() => {
+      timers.delete(timer);
+      callback();
+    }, delay);
+    timers.add(timer);
+  }
+
+  function clearRateLimit() {
+    if (rateLimitTimer) clearTimeout(rateLimitTimer);
+    rateLimitTimer = undefined;
+    reactionsRateLimited.value = false;
+  }
+
+  function applyRateLimit(retryAfterMs: number) {
+    clearRateLimit();
+    const delay = Math.max(0, Math.ceil(retryAfterMs));
+    if (delay === 0) return;
+
+    reactionsRateLimited.value = true;
+    rateLimitTimer = setTimeout(() => {
+      rateLimitTimer = undefined;
+      reactionsRateLimited.value = false;
+    }, delay);
+  }
+
+  function show(emoji: ReactionEmoji, reactingUsername: string) {
+    const PADDING_PERCENTAGE = 10;
+
+    const reaction: RoomReaction = {
+      id: ++nextReactionId,
+      emoji,
+      who: reactingUsername === session.username.value ? "You" : reactingUsername,
+      x: PADDING_PERCENTAGE + Math.random() * (100 - 2 * PADDING_PERCENTAGE),
+    };
+
+    reactionBursts.value = [...reactionBursts.value, reaction].slice(-MAX_VISIBLE_BURSTS);
+    reactionFeed.value = [reaction, ...reactionFeed.value].slice(0, MAX_FEED_ITEMS);
+
+    scheduleCleanup(() => {
+      reactionBursts.value = reactionBursts.value.filter((item) => item.id !== reaction.id);
+    }, BURST_LIFETIME_MS);
+    scheduleCleanup(() => {
+      reactionFeed.value = reactionFeed.value.filter((item) => item.id !== reaction.id);
+    }, FEED_LIFETIME_MS);
+  }
+
+  function sendReaction(emoji: ReactionEmoji) {
+    if (!canReact.value) return;
+    sendReactionMessage(emoji);
+  }
+
+  function dispose() {
+    clearRateLimit();
+    timers.forEach(clearTimeout);
+    timers.clear();
+    reactionBursts.value = [];
+    reactionFeed.value = [];
+  }
+
+  return {
+    canReact,
+    reactionBursts,
+    reactionFeed,
+    reactionsRateLimited,
+    applyRateLimit,
+    clearRateLimit,
+    dispose,
+    sendReaction,
+    show,
+  };
+}

--- a/frontend/src/composables/useRoomSession.ts
+++ b/frontend/src/composables/useRoomSession.ts
@@ -21,6 +21,7 @@ import {
 } from "@/modules/socket";
 import { createRoomMembers } from "@/modules/roomMembers";
 import { rememberRoomDeck } from "@/composables/useRecentRooms";
+import { useReactions } from "@/composables/useReactions";
 import { useRootStore } from "@/stores/root";
 
 export function useRoomSession(id: string) {
@@ -43,6 +44,7 @@ export function useRoomSession(id: string) {
   const usernameModel = ref(localStorage.getItem(usernameKey) ?? "");
   const copiedRoomLink = ref(false);
   const adminSheetOpen = ref(false);
+  const reactions = useReactions({ username, connectionStatus });
 
   const socketUrl = import.meta.env.VITE_SOCKET_URL;
   if (!socketUrl) {
@@ -136,6 +138,7 @@ export function useRoomSession(id: string) {
   function handleWebSocketMessage(msg: ServerMessage) {
     switch (msg.type) {
       case "joinRoomSuccess":
+        reactions.clearRateLimit();
         participants.value = new Map(Object.entries(msg.data.participants));
         store.setAdmin(msg.data.admin);
         votesLocked.value = msg.data.locked;
@@ -147,6 +150,12 @@ export function useRoomSession(id: string) {
         applyDeck(msg.data.deck);
         store.clearVotes();
         addNotification(`Deck changed to ${decks[msg.data.deck].label} — votes were reset`);
+        break;
+      case "reaction":
+        reactions.show(msg.data.emoji, msg.data.username);
+        break;
+      case "reactionRateLimited":
+        reactions.applyRateLimit(msg.data.retryAfterMs);
         break;
       case "userJoined":
         store.addParticipant({ username: msg.data.username });
@@ -271,12 +280,14 @@ export function useRoomSession(id: string) {
   }
 
   function teardownRoomSession() {
+    reactions.dispose();
     disconnect();
     store.$reset();
   }
 
   return {
     adminSheetOpen,
+    canReact: reactions.canReact,
     connectionStatus,
     copiedRoomLink,
     deck,
@@ -287,6 +298,9 @@ export function useRoomSession(id: string) {
     members,
     pointEstimate,
     points,
+    reactionBursts: reactions.reactionBursts,
+    reactionFeed: reactions.reactionFeed,
+    reactionsRateLimited: reactions.reactionsRateLimited,
     roomId,
     totalCount,
     usernameModel,
@@ -300,6 +314,7 @@ export function useRoomSession(id: string) {
     join,
     leaveRoom,
     makeAdmin,
+    sendReaction: reactions.sendReaction,
     startNewRound,
     teardownRoomSession,
     toggleVoteLock,

--- a/frontend/src/modules/socket.ts
+++ b/frontend/src/modules/socket.ts
@@ -1,4 +1,4 @@
-import type { ServerMessage, ClientMessage, DeckId } from "@shared/types";
+import type { ServerMessage, ClientMessage, DeckId, ReactionEmoji } from "@shared/types";
 
 export type ConnectionStatus = "connected" | "disconnected" | "reconnecting" | "failed";
 
@@ -152,4 +152,8 @@ export function removeParticipant(participant: string) {
 
 export function changeDeck(deck: DeckId) {
   send({ type: "changeDeck", data: { deck } });
+}
+
+export function sendReaction(emoji: ReactionEmoji) {
+  send({ type: "sendReaction", data: { emoji } });
 }

--- a/frontend/src/views/RoomView.vue
+++ b/frontend/src/views/RoomView.vue
@@ -9,6 +9,8 @@ import VotingProgress from "@/components/VotingProgress.vue";
 import VoteDistribution from "@/components/VoteDistribution.vue";
 import ParticipantManageSheet from "@/components/ParticipantManageSheet.vue";
 import HandStrip from "@/components/HandStrip.vue";
+import ReactionBar from "@/components/ReactionBar.vue";
+import ReactionFeed from "@/components/ReactionFeed.vue";
 import DeckChooserView from "@/views/DeckChooserView.vue";
 import { useRoomSession } from "@/composables/useRoomSession";
 import { deckTone } from "@/modules/deckTone";
@@ -17,6 +19,7 @@ import { changeDeck } from "@/modules/socket";
 const props = defineProps<{ id: string }>();
 const {
   adminSheetOpen,
+  canReact,
   connectionStatus,
   copiedRoomLink,
   deck,
@@ -27,6 +30,9 @@ const {
   members,
   pointEstimate,
   points,
+  reactionBursts,
+  reactionFeed,
+  reactionsRateLimited,
   roomId,
   totalCount,
   usernameModel,
@@ -40,6 +46,7 @@ const {
   join,
   leaveRoom,
   makeAdmin,
+  sendReaction,
   startNewRound,
   teardownRoomSession,
   toggleVoteLock,
@@ -184,11 +191,28 @@ onBeforeRouteLeave(() => {
             />
           </div>
           <p v-else class="empty">Waiting for participants…</p>
+
+          <div class="reaction-burst-layer" aria-hidden="true">
+            <span
+              v-for="reaction in reactionBursts"
+              :key="reaction.id"
+              class="reaction-burst"
+              :style="{ left: `${reaction.x}%` }"
+            >
+              {{ reaction.emoji }}
+            </span>
+          </div>
         </section>
 
         <aside class="rail">
           <VoteDistribution v-if="votesVisible" :members="members" :cards="points" />
           <VotingProgress v-else :members="members" />
+          <ReactionBar
+            :disabled="!canReact"
+            :rate-limited="reactionsRateLimited"
+            @react="sendReaction"
+          />
+          <ReactionFeed v-if="reactionFeed.length" :items="reactionFeed" />
         </aside>
       </div>
 
@@ -762,6 +786,8 @@ main {
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
+    z-index: 3;
   }
 
   .vote-pill {
@@ -790,6 +816,8 @@ main {
   }
 
   .grid {
+    position: relative;
+    z-index: 1;
     flex: 1 1 auto;
     min-height: 0;
     display: flex;
@@ -818,6 +846,25 @@ main {
     }
   }
 
+  .reaction-burst-layer {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    overflow: hidden;
+    border-radius: inherit;
+    pointer-events: none;
+  }
+
+  .reaction-burst {
+    position: absolute;
+    bottom: 16%;
+    filter: drop-shadow(0 0.35rem 0.65rem rgb(0 0 0 / 45%));
+    font-size: clamp(1.75rem, 3.5vw, 2.4rem);
+    line-height: 1;
+    will-change: transform, opacity;
+    animation: reaction-float 1.8s ease-out forwards;
+  }
+
   .empty {
     color: var(--p-text-muted-color);
     text-align: center;
@@ -829,7 +876,39 @@ main {
   display: none;
 
   @media (min-width: 1024px) {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+    align-self: start;
+  }
+}
+
+@keyframes reaction-float {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 1.25rem) scale(0.65) rotate(-8deg);
+  }
+
+  16% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1.08) rotate(3deg);
+  }
+
+  72% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -11rem) scale(1.25) rotate(9deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .board .reaction-burst {
+    opacity: 1;
+    transform: translateX(-50%);
+    animation: none;
   }
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -77,6 +77,21 @@ export function isVoteForDeck(deckId: DeckId, value: string): boolean {
   return decks[deckId].cards.includes(value)
 }
 
+/**
+ * The deliberately small reaction set available in a room. Keeping this
+ * shared lets the frontend render the picker while the backend validates
+ * every incoming reaction against the same allowlist.
+ */
+export const reactionEmojis = ['👍', '🎉', '🤔', '👀', '⏳', '☕'] as const
+export type ReactionEmoji = (typeof reactionEmojis)[number]
+
+export function isReactionEmoji(value: unknown): value is ReactionEmoji {
+  return (
+    typeof value === 'string' &&
+    (reactionEmojis as readonly string[]).includes(value)
+  )
+}
+
 export type WebSocketData = {
   roomId: string
   username: string
@@ -126,6 +141,11 @@ export type ChangeDeckMessage = {
   data: { deck: string }
 }
 
+export type SendReactionMessage = {
+  type: 'sendReaction'
+  data: { emoji: ReactionEmoji }
+}
+
 export type ClientMessage =
   | SubmitVoteMessage
   | RevealVotesMessage
@@ -136,6 +156,7 @@ export type ClientMessage =
   | TransferAdminMessage
   | RemoveParticipantMessage
   | ChangeDeckMessage
+  | SendReactionMessage
 
 // ── Server → Client messages ──
 
@@ -229,6 +250,22 @@ export type DeckChangedMessage = {
   data: { deck: DeckId }
 }
 
+/**
+ * A reaction is broadcast live and is never included in room snapshots.
+ * The backend supplies `username` from the authenticated socket rather
+ * than accepting it from the client.
+ */
+export type ReactionMessage = {
+  type: 'reaction'
+  data: { username: string; emoji: ReactionEmoji }
+}
+
+/** Sent only to the participant whose reaction exceeded the live rate limit. */
+export type ReactionRateLimitedMessage = {
+  type: 'reactionRateLimited'
+  data: { retryAfterMs: number }
+}
+
 export type ServerMessage =
   | JoinRoomSuccessMessage
   | UserJoinedMessage
@@ -246,3 +283,5 @@ export type ServerMessage =
   | UserDisconnectedMessage
   | UserReconnectedMessage
   | DeckChangedMessage
+  | ReactionMessage
+  | ReactionRateLimitedMessage


### PR DESCRIPTION
## Summary

Add lightweight, ephemeral emoji reactions to Scrum Poker rooms.

## What changed

- Add a shared allowlist and WebSocket message types for reactions.
- Broadcast reactions live without persisting them in room snapshots.
- Add per-connection token-bucket rate limiting with retry feedback.
- Add a `useReactions` composable with timer cleanup, rate-limit state, and session integration.
- Add reaction picker/feed UI and animated floating reactions with reduced-motion support.
- Add backend coverage for reaction rate limiting and update the project roadmap.

## Notes

Reactions are intentionally limited to a small set of emojis and are available only while connected and not rate-limited.