### PR TITLE
feat: add optional sound cues for room events

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Most of these are additive to the `ClientMessage`/`ServerMessage` unions in
 ### Tier 3 — Consider, but watch the "no fluff" line
 
 - **Light-mode toggle** — The app currently forces dark mode (`modules/darkMode.ts`).
-- **Opt-in sound/notification** on reveal or "your turn".
 
 ### Explicitly out of scope
 

--- a/frontend/src/composables/useRoomSession.ts
+++ b/frontend/src/composables/useRoomSession.ts
@@ -22,6 +22,7 @@ import {
 import { createRoomMembers } from "@/modules/roomMembers";
 import { rememberRoomDeck } from "@/composables/useRecentRooms";
 import { useReactions } from "@/composables/useReactions";
+import { useSoundCues } from "@/composables/useSoundCues";
 import { useRootStore } from "@/stores/root";
 
 export function useRoomSession(id: string) {
@@ -39,6 +40,10 @@ export function useRoomSession(id: string) {
     pointEstimate,
     deck,
   } = storeToRefs(store);
+
+  // Cues fire only on incoming server messages, so self-initiated new
+  // rounds stay silent (the server doesn't echo votesCleared to the actor).
+  const { soundCuesEnabled, toggleSoundCues, playRevealCue, playNewRoundCue } = useSoundCues();
 
   const connectionStatus = ref<ConnectionStatus>("disconnected");
   const usernameModel = ref(localStorage.getItem(usernameKey) ?? "");
@@ -149,6 +154,7 @@ export function useRoomSession(id: string) {
       case "deckChanged":
         applyDeck(msg.data.deck);
         store.clearVotes();
+        playNewRoundCue();
         addNotification(`Deck changed to ${decks[msg.data.deck].label} — votes were reset`);
         break;
       case "reaction":
@@ -173,6 +179,7 @@ export function useRoomSession(id: string) {
         store.setParticipantPointEstimate(msg.data.username, msg.data.vote);
         break;
       case "voteStatus":
+        if (msg.data.revealed && !votesVisible.value) playRevealCue();
         participants.value = new Map(Object.entries(msg.data.votes));
         votesVisible.value = msg.data.revealed;
         if (!msg.data.revealed) restoreOwnVote();
@@ -180,6 +187,7 @@ export function useRoomSession(id: string) {
       case "votesCleared":
         store.clearVotes();
         votesVisible.value = false;
+        playNewRoundCue();
         break;
       case "voteLockStatus":
         votesLocked.value = msg.data.locked;
@@ -302,6 +310,7 @@ export function useRoomSession(id: string) {
     reactionFeed: reactions.reactionFeed,
     reactionsRateLimited: reactions.reactionsRateLimited,
     roomId,
+    soundCuesEnabled,
     totalCount,
     usernameModel,
     votedCount,
@@ -317,6 +326,7 @@ export function useRoomSession(id: string) {
     sendReaction: reactions.sendReaction,
     startNewRound,
     teardownRoomSession,
+    toggleSoundCues,
     toggleVoteLock,
     toggleVoteVisibility,
     vote,

--- a/frontend/src/composables/useSoundCues.ts
+++ b/frontend/src/composables/useSoundCues.ts
@@ -1,0 +1,85 @@
+import { ref } from "vue";
+import { soundCuesKey } from "@/modules/constants";
+
+type Note = {
+  freq: number;
+  /** Seconds after the cue starts. */
+  startOffset: number;
+  duration: number;
+};
+
+// Module scope so every caller shares one preference and one AudioContext.
+const soundCuesEnabled = ref(localStorage.getItem(soundCuesKey) === "true");
+let audioCtx: AudioContext | null = null;
+let lastCueAt = 0;
+
+const CUE_DEBOUNCE_MS = 250;
+// Quiet peak (~ -24 dB): a nudge, not an alarm.
+const PEAK_GAIN = 0.06;
+
+function getContext() {
+  if (typeof AudioContext === "undefined") return null;
+  audioCtx ??= new AudioContext();
+  return audioCtx;
+}
+
+function playNote(ctx: AudioContext, { freq, startOffset, duration }: Note) {
+  const start = ctx.currentTime + startOffset;
+  const osc = new OscillatorNode(ctx, { type: "sine", frequency: freq });
+  const gain = new GainNode(ctx, { gain: 0.0001 });
+  gain.gain.setValueAtTime(0.0001, start);
+  gain.gain.linearRampToValueAtTime(PEAK_GAIN, start + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+  osc.connect(gain).connect(ctx.destination);
+  osc.start(start);
+  osc.stop(start + duration + 0.05);
+}
+
+function playCue(notes: Note[]) {
+  if (!soundCuesEnabled.value) return;
+  const now = performance.now();
+  if (now - lastCueAt < CUE_DEBOUNCE_MS) return;
+  lastCueAt = now;
+
+  const ctx = getContext();
+  if (!ctx) return;
+  const schedule = () => notes.forEach((note) => playNote(ctx, note));
+  // Background tabs suspend the context; resume before playing — a cue
+  // is most useful exactly when the tab isn't focused. If the browser
+  // still blocks (no user gesture yet after page load), skip silently.
+  if (ctx.state === "suspended") {
+    ctx.resume().then(schedule, () => {});
+  } else {
+    schedule();
+  }
+}
+
+/** Ascending two-note "ta-da" when votes are revealed. */
+function playRevealCue() {
+  playCue([
+    { freq: 660, startOffset: 0, duration: 0.3 },
+    { freq: 880, startOffset: 0.09, duration: 0.35 },
+  ]);
+}
+
+/** Single mellow note when a new round starts — your turn to vote. */
+function playNewRoundCue() {
+  playCue([{ freq: 523, startOffset: 0, duration: 0.35 }]);
+}
+
+function toggleSoundCues() {
+  soundCuesEnabled.value = !soundCuesEnabled.value;
+  localStorage.setItem(soundCuesKey, String(soundCuesEnabled.value));
+  // The enabling click is the user gesture browsers require before audio
+  // may play; use it to unlock the context and confirm sound works.
+  if (soundCuesEnabled.value) playNewRoundCue();
+}
+
+export function useSoundCues() {
+  return {
+    soundCuesEnabled,
+    toggleSoundCues,
+    playRevealCue,
+    playNewRoundCue,
+  };
+}

--- a/frontend/src/modules/constants.ts
+++ b/frontend/src/modules/constants.ts
@@ -1,1 +1,2 @@
 export const usernameKey = "username";
+export const soundCuesKey = "sound-cues-enabled";

--- a/frontend/src/views/RoomView.vue
+++ b/frontend/src/views/RoomView.vue
@@ -34,6 +34,7 @@ const {
   reactionFeed,
   reactionsRateLimited,
   roomId,
+  soundCuesEnabled,
   totalCount,
   usernameModel,
   votedCount,
@@ -49,6 +50,7 @@ const {
   sendReaction,
   startNewRound,
   teardownRoomSession,
+  toggleSoundCues,
   toggleVoteLock,
   toggleVoteVisibility,
   vote,
@@ -79,7 +81,7 @@ onBeforeRouteLeave(() => {
         <div class="brand-text">
           <span class="overline">ROOM</span>
           <span class="room-id">
-            {{ roomId.toUpperCase() }}
+            <span class="id-text">{{ roomId.toUpperCase() }}</span>
             <span class="deck-chip">{{ deckLabel }} deck</span>
           </span>
         </div>
@@ -93,6 +95,15 @@ onBeforeRouteLeave(() => {
         >
           <i class="pi pi-pencil" />
           <span class="hide-mobile">Change deck</span>
+        </button>
+        <button
+          class="ghost-btn sound"
+          :aria-label="soundCuesEnabled ? 'Turn sound cues off' : 'Turn sound cues on'"
+          :aria-pressed="soundCuesEnabled"
+          @click="toggleSoundCues"
+        >
+          <i :class="soundCuesEnabled ? 'pi pi-volume-up' : 'pi pi-volume-off'" />
+          <span class="hide-mobile">{{ soundCuesEnabled ? "Sound on" : "Sound off" }}</span>
         </button>
         <button
           class="ghost-btn invite"
@@ -292,8 +303,8 @@ main {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  padding: 0.85rem clamp(1rem, 3vw, 1.75rem);
+  gap: clamp(0.5rem, 2vw, 1rem);
+  padding: 0.85rem clamp(0.75rem, 3vw, 1.75rem);
   background: color-mix(in srgb, var(--p-content-background) 88%, black);
   border-bottom: 1px solid var(--p-content-border-color);
 
@@ -338,12 +349,23 @@ main {
 
     .room-id {
       display: inline-flex;
+      // Drop the deck chip to its own line instead of colliding with
+      // the header actions when the viewport is narrow.
+      flex-wrap: wrap;
+      min-width: 0;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.15rem 0.5rem;
       font-family: ui-monospace, monospace;
       font-weight: 700;
       font-size: 1.05rem;
       letter-spacing: 0.04em;
+
+      .id-text {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     .deck-chip {
@@ -359,12 +381,16 @@ main {
       font-weight: 500;
       letter-spacing: 0.02em;
       white-space: nowrap;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 
   .header-actions {
     display: flex;
     gap: 0.5rem;
+    flex-shrink: 0;
   }
 }
 
@@ -372,7 +398,9 @@ main {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.5rem 0.85rem;
+  // Icon-only below 768px (labels are .hide-mobile) — slim the padding
+  // so four buttons leave the brand text some room.
+  padding: 0.5rem 0.6rem;
   border-radius: 0.6rem;
   background: transparent;
   border: 1px solid var(--p-content-border-color);
@@ -402,6 +430,18 @@ main {
     animation: pencil-scribble 550ms ease-in-out;
   }
 
+  &.sound {
+    // Hover only wobbles the off-state icon (like .invite) so the
+    // pop below isn't overridden while the cursor is still on the button.
+    &:hover .pi-volume-off {
+      animation: sound-ring 650ms ease-in-out;
+    }
+
+    .pi-volume-up {
+      animation: check-pop 350ms ease-out;
+    }
+  }
+
   &.leave:hover .pi {
     animation: leave-scoot 0.5s ease-in-out;
   }
@@ -415,7 +455,9 @@ main {
     display: none;
   }
 
-  @media (min-width: 480px) {
+  @media (min-width: 768px) {
+    padding: 0.5rem 0.85rem;
+
     .hide-mobile {
       display: inline;
     }
@@ -713,6 +755,29 @@ main {
 
   100% {
     transform: scale(1) rotate(0deg);
+  }
+}
+
+@keyframes sound-ring {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+
+  20% {
+    transform: rotate(-14deg) scale(1.12);
+  }
+
+  45% {
+    transform: rotate(10deg) scale(1.06);
+  }
+
+  70% {
+    transform: rotate(-6deg) scale(1);
+  }
+
+  85% {
+    transform: rotate(3deg) scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary

Add opt-in audio cues for important room events while keeping sound disabled by default.

## What changed

- Add a shared sound preference persisted in local storage.
- Add a reusable sound-cue composable backed by the Web Audio API.
- Play an ascending cue when votes are revealed and a subtle cue when a new round starts.
- Add a room-header control with accessible on/off state and mobile-friendly layout.
- Handle suspended audio contexts, browser gesture requirements, cue debouncing, and quiet output levels.
- Remove the completed sound-cue item from the roadmap.