### PR TITLE
Give room membership a home

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,6 +3,63 @@
 Glossary of domain terms. Grown lazily: a term is added when a piece of
 work actually resolves it (see `docs/agents/domain.md`), not speculatively.
 
+## Membership
+
+A name on a room's roster (`room.users`). Membership is what other
+members see: `userJoined`, `userLeft`, `participantRemoved` and
+`roomClosed` all announce a membership change, and a
+[Snapshot](#snapshot) lists exactly the current members.
+
+Membership transitions live in one place, `backend/src/roomMembership.ts`
+— `arrive`, `depart` and `evict`. That module is the only thing that
+sequences the room roster, the connection registry and the disconnect
+registry together; nothing else may mutate more than one of them.
+
+## Presence
+
+Whether a member holds a live socket right now. Presence is *not*
+membership: the two disagree for the length of a
+[Grace period](#grace-period), and that gap is the whole reason both
+facts are tracked. `ConnectionManager` owns presence; `RoomManager` owns
+membership.
+
+A member who is absent still counts as a member — they hold their seat,
+their vote, and their name against a would-be duplicate.
+
+## Grace period
+
+The 30 seconds after an unexpected socket close during which a member
+keeps their membership without presence. Announced with
+`userDisconnected` on entry and, if it expires, `userLeft`. Reconnecting
+inside the window restores presence and replays a
+[Snapshot](#snapshot); nothing about the member's membership changed, so
+the room hears `userReconnected` rather than a rejoin.
+
+Held by `DisconnectManager`, whose timers run through an injectable
+scheduler so expiry is testable by advancing a clock rather than
+sleeping.
+
+## Departure reason
+
+Why a socket closed, and therefore what the room is told. Derived from
+the close frame **and** room state — an admin's departure closes the room
+whatever reason their client sent, so this is not a pure decode of the
+frame.
+
+| Reason          | Trigger                        | Effect                             |
+| --------------- | ------------------------------ | ---------------------------------- |
+| `usernameTaken` | close code `4001`              | silent — nothing was registered    |
+| `adminLeft`     | departing member is the admin  | `roomClosed`, room destroyed       |
+| `evicted`       | reason `Removed by admin`      | silent — `evict` already announced |
+| `left`          | reason `User left room`        | `userLeft`, no grace period        |
+| `lost`          | anything else                  | `userDisconnected` → grace period  |
+
+The order matters and is asserted: `adminLeft` is checked before the
+reason strings. The two reason strings and the close codes are the wire
+contract (`CloseReason`, `CloseCode` in `shared/types.ts`) — both the
+frontend and the backend import them rather than repeating literals,
+because a typo would silently reclassify a departure.
+
 ## Snapshot
 
 The authoritative view of a room a client receives on join or reconnect

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,6 +3,19 @@
 Glossary of domain terms. Grown lazily: a term is added when a piece of
 work actually resolves it (see `docs/agents/domain.md`), not speculatively.
 
+## Room id
+
+The name a room is reached by. Case- and whitespace-insensitive:
+`Sprint42`, `sprint42` and ` sprint42 ` are one room. Every entry point
+normalizes through `normalizeRoomId` in `shared/types.ts` — the HTTP
+existence probe, the socket upgrade, the frontend's route handling and
+the seed script.
+
+The rule has to be shared because the probe and the socket must agree: a
+room existing under one spelling while the probe reports it missing under
+another sends two people who think they are in the same room into two
+different ones, silently.
+
 ## Membership
 
 A name on a room's roster (`room.users`). Membership is what other

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,6 +15,12 @@ Membership transitions live in one place, `backend/src/roomMembership.ts`
 sequences the room roster, the connection registry and the disconnect
 registry together; nothing else may mutate more than one of them.
 
+A room ends when it loses its admin, and only then: any other member can
+leave without ending the session, and the admin is necessarily the last
+one standing because `transferAdmin` moves the role rather than vacating
+it. `leaveRoom` reports this as `destroyed` — the room is gone and the
+remaining members must be told.
+
 ## Presence
 
 Whether a member holds a live socket right now. Presence is *not*
@@ -30,7 +36,9 @@ their vote, and their name against a would-be duplicate.
 
 The 30 seconds after an unexpected socket close during which a member
 keeps their membership without presence. Announced with
-`userDisconnected` on entry and, if it expires, `userLeft`. Reconnecting
+`userDisconnected` on entry and, if it expires, `userLeft` — or
+`roomClosed`, when the member who expired had meanwhile been made admin
+(`transferAdmin` accepts an absent member). Reconnecting
 inside the window restores presence and replays a
 [Snapshot](#snapshot); nothing about the member's membership changed, so
 the room hears `userReconnected` rather than a rejoin.

--- a/backend/scripts/seed-room.ts
+++ b/backend/scripts/seed-room.ts
@@ -7,6 +7,8 @@
 // when this script exits. Ctrl+C makes every seeded user leave immediately
 // (no reconnect grace period).
 
+import { normalizeRoomId } from "@shared/types";
+
 const NAMES = [
   "Goku",
   "Vegeta",
@@ -41,7 +43,10 @@ const NAMES = [
 ];
 
 const args = process.argv.slice(2);
-const roomId = args.find((a) => !a.startsWith("--"));
+const rawRoomId = args.find((a) => !a.startsWith("--"));
+// Normalized so `seed Sprint42` seeds the same room a browser reaches at
+// /room/Sprint42, rather than a second one keyed by the exact casing.
+const roomId = rawRoomId ? normalizeRoomId(rawRoomId) : undefined;
 
 function flag(name: string, fallback: string): string {
   const idx = args.indexOf(`--${name}`);

--- a/backend/src/__tests__/clientMessageHandler.test.ts
+++ b/backend/src/__tests__/clientMessageHandler.test.ts
@@ -1,77 +1,34 @@
 import type { ServerWebSocket } from "bun";
 import { describe, expect, test } from "bun:test";
-import type { ClientMessage, ServerMessage, WebSocketData } from "@shared/types";
+import type { ClientMessage, WebSocketData } from "@shared/types";
 import { createClientMessageHandler } from "../clientMessageHandler";
 import { ConnectionManager } from "../connectionManager";
+import { DisconnectManager } from "../disconnectManager";
 import { REACTION_REFILL_INTERVAL_MS, ReactionRateLimiter } from "../reactionRateLimiter";
 import { InMemoryRoomManager } from "../roomManager";
-import type { RoomBroadcaster } from "../roomBroadcaster";
+import { createRoomMembership } from "../roomMembership";
+import { fakeSocket, payloadFor, recordingBroadcaster } from "./testDoubles";
 
 type Socket = ServerWebSocket<WebSocketData>;
-
-type FakeSocket = Socket & {
-  sent: string[];
-  closed?: { code?: number; reason?: string };
-};
-
-function fakeSocket(roomId: string, username: string): FakeSocket {
-  const socket = {
-    data: { roomId, username },
-    sent: [] as string[],
-    closed: undefined as { code?: number; reason?: string } | undefined,
-    send(raw: string) {
-      socket.sent.push(raw);
-    },
-    close(code?: number, reason?: string) {
-      socket.closed = { code, reason };
-    },
-  };
-  return socket as unknown as FakeSocket;
-}
-
-type EachMemberCall = {
-  to: "eachMember";
-  roomId: string;
-  build: (username: string) => ServerMessage;
-};
-
-type BroadcastCall =
-  | { to: "room"; roomId: string; msg: ServerMessage }
-  | { to: "roomExcept"; sender: Socket; msg: ServerMessage }
-  | { to: "user"; roomId: string; username: string; msg: ServerMessage }
-  | EachMemberCall
-  | { to: "reply"; ws: Socket; msg: ServerMessage };
-
-/** The seam's second adapter: records every broadcast instead of sending. */
-function recordingBroadcaster() {
-  const calls: BroadcastCall[] = [];
-  const broadcaster: RoomBroadcaster = {
-    toRoom: (roomId, msg) => calls.push({ to: "room", roomId, msg }),
-    toRoomExcept: (sender, msg) => calls.push({ to: "roomExcept", sender, msg }),
-    toUser: (roomId, username, msg) => calls.push({ to: "user", roomId, username, msg }),
-    toEachMember: (roomId, build) => calls.push({ to: "eachMember", roomId, build }),
-    reply: (ws, msg) => calls.push({ to: "reply", ws, msg }),
-  };
-  return { broadcaster, calls };
-}
-
-/** The personalized payload a given member would have received. */
-function payloadFor(call: BroadcastCall | undefined, username: string): ServerMessage {
-  if (!call || call.to !== "eachMember") throw new Error(`Expected an eachMember call, got ${call?.to}`);
-  return call.build(username);
-}
 
 function setup() {
   const roomManager = new InMemoryRoomManager();
   const connectionManager = new ConnectionManager();
+  const disconnectManager = new DisconnectManager();
   let now = 0;
   const rateLimiter = new ReactionRateLimiter(() => now);
   const { broadcaster, calls } = recordingBroadcaster();
-  const handler = createClientMessageHandler({
+  const membership = createRoomMembership({
     roomManager,
     connectionManager,
+    disconnectManager,
+    broadcaster,
+  });
+  const handler = createClientMessageHandler({
+    roomManager,
     broadcaster,
     rateLimiter,
+    membership,
   });
 
   // Standard room: an admin voter, a second voter, and a spectator.
@@ -415,42 +372,28 @@ describe("clientMessageHandler", () => {
     });
   });
 
+  // The eviction sequence itself is a membership transition and is
+  // covered in roomMembership.test.ts. What belongs here is the wiring:
+  // the message reaches evict(), and a refusal becomes an error reply.
   describe("removeParticipant", () => {
-    test("removes a connected member: notify them, close them, tell the room", () => {
+    test("delegates to the membership seam", () => {
       const { roomManager, connectionManager, calls, send, admin, voter } = setup();
       connectionManager.registerConnection("room1", "voter", voter);
 
       send(admin, { type: "removeParticipant", data: { participant: "voter" } });
 
       expect(roomManager.isUserInRoom("room1", "voter")).toBe(false);
-      expect(voter.closed).toEqual({ code: 1000, reason: "Removed by admin" });
-      expect(connectionManager.isConnected("room1", "voter")).toBe(false);
-      expect(calls).toEqual([
-        {
-          to: "user",
-          roomId: "room1",
-          username: "voter",
-          msg: { type: "youWereRemoved", data: { removedBy: "admin" } },
-        },
-        {
-          to: "room",
-          roomId: "room1",
-          msg: {
-            type: "participantRemoved",
-            data: { removedBy: "admin", participant: "voter" },
-          },
-        },
+      expect(calls.map((call) => call.msg.type)).toEqual([
+        "youWereRemoved",
+        "participantRemoved",
       ]);
     });
 
-    test("removing a member in the disconnect grace period broadcasts nothing", () => {
-      // No live connection: the room learns of the removal when the
-      // grace period expires (userLeft) — preserved wire behavior.
-      const { roomManager, calls, send, admin } = setup();
+    test("a missing participant is ignored, not dispatched", () => {
+      const { calls, send, admin } = setup();
 
-      send(admin, { type: "removeParticipant", data: { participant: "voter" } });
+      send(admin, { type: "removeParticipant", data: { participant: "" } });
 
-      expect(roomManager.isUserInRoom("room1", "voter")).toBe(false);
       expect(calls).toEqual([]);
     });
 

--- a/backend/src/__tests__/disconnectManager.test.ts
+++ b/backend/src/__tests__/disconnectManager.test.ts
@@ -1,17 +1,17 @@
-import { expect, test, describe, beforeEach, afterEach, mock } from "bun:test";
+import { expect, test, describe, beforeEach, mock } from "bun:test";
 import { DisconnectManager } from "../disconnectManager";
+import { fakeScheduler } from "./testDoubles";
 
 describe("DisconnectManager", () => {
   let disconnectManager: DisconnectManager;
+  let advance: (ms: number) => void;
 
   beforeEach(() => {
-    disconnectManager = new DisconnectManager();
-  });
-
-  afterEach(() => {
-    // Clean up any remaining timers
-    disconnectManager.clearRoom("room1");
-    disconnectManager.clearRoom("room2");
+    // Expiry is asserted by advancing a fake clock, so no test sleeps and
+    // no timer survives the run.
+    const clock = fakeScheduler();
+    advance = clock.advance;
+    disconnectManager = new DisconnectManager(clock.scheduler);
   });
 
   describe("markDisconnected", () => {
@@ -22,20 +22,22 @@ describe("DisconnectManager", () => {
       expect(disconnectManager.isDisconnected("room1", "user1")).toBe(true);
     });
 
-    test("should call onExpiry after grace period", async () => {
+    test("should call onExpiry after grace period", () => {
       const onExpiry = mock(() => {});
       disconnectManager.markDisconnected("room1", "user1", onExpiry, 50);
 
+      advance(49);
       expect(onExpiry).not.toHaveBeenCalled();
-      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      advance(1);
       expect(onExpiry).toHaveBeenCalledTimes(1);
     });
 
-    test("should remove user from disconnected after expiry", async () => {
+    test("should remove user from disconnected after expiry", () => {
       const onExpiry = mock(() => {});
       disconnectManager.markDisconnected("room1", "user1", onExpiry, 50);
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      advance(50);
       expect(disconnectManager.isDisconnected("room1", "user1")).toBe(false);
     });
   });
@@ -50,12 +52,12 @@ describe("DisconnectManager", () => {
       expect(disconnectManager.isDisconnected("room1", "user1")).toBe(false);
     });
 
-    test("should not call onExpiry after cancel", async () => {
+    test("should not call onExpiry after cancel", () => {
       const onExpiry = mock(() => {});
       disconnectManager.markDisconnected("room1", "user1", onExpiry, 50);
 
       disconnectManager.cancelDisconnect("room1", "user1");
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      advance(100);
       expect(onExpiry).not.toHaveBeenCalled();
     });
 
@@ -106,12 +108,12 @@ describe("DisconnectManager", () => {
       expect(disconnectManager.isDisconnected("room1", "user2")).toBe(false);
     });
 
-    test("should not call onExpiry after clearing", async () => {
+    test("should not call onExpiry after clearing", () => {
       const onExpiry = mock(() => {});
       disconnectManager.markDisconnected("room1", "user1", onExpiry, 50);
 
       disconnectManager.clearRoom("room1");
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      advance(100);
       expect(onExpiry).not.toHaveBeenCalled();
     });
 

--- a/backend/src/__tests__/roomManager.test.ts
+++ b/backend/src/__tests__/roomManager.test.ts
@@ -206,7 +206,7 @@ describe("InMemoryRoomManager", () => {
       roomManager.joinRoom("room1", "admin");
       roomManager.joinRoom("room1", "user1");
       const result = roomManager.leaveRoom("room1", "admin");
-      expect(result.shouldDestroyRoom).toBe(true);
+      expect(result.destroyed).toBe(true);
       expect(roomManager.getRoomUsers("room1")).toEqual([]);
       expect(() => roomManager.submitVote("room1", "user1", "5")).toThrow("Room does not exist");
     });
@@ -215,8 +215,30 @@ describe("InMemoryRoomManager", () => {
       roomManager.joinRoom("room1", "admin");
       roomManager.joinRoom("room1", "user1");
       const result = roomManager.leaveRoom("room1", "user1");
-      expect(result.shouldDestroyRoom).toBe(false);
+      expect(result.destroyed).toBe(false);
       expect(roomManager.getRoomUsers("room1")).toEqual(["admin"]);
+    });
+
+    test("the last non-admin leaving keeps the room open for the admin", () => {
+      roomManager.joinRoom("room1", "admin");
+      roomManager.joinRoom("room1", "user1");
+
+      expect(roomManager.leaveRoom("room1", "user1").destroyed).toBe(false);
+      expect(roomManager.roomExists("room1")).toBe(true);
+      expect(roomManager.getRoomUsers("room1")).toEqual(["admin"]);
+    });
+
+    test("destruction follows the admin role, not the original creator", () => {
+      roomManager.joinRoom("room1", "admin");
+      roomManager.joinRoom("room1", "user1");
+      roomManager.transferAdmin("room1", "admin", "user1");
+
+      // The creator is now an ordinary member.
+      expect(roomManager.leaveRoom("room1", "admin").destroyed).toBe(false);
+      expect(roomManager.roomExists("room1")).toBe(true);
+
+      expect(roomManager.leaveRoom("room1", "user1").destroyed).toBe(true);
+      expect(roomManager.roomExists("room1")).toBe(false);
     });
   });
 

--- a/backend/src/__tests__/roomMembership.test.ts
+++ b/backend/src/__tests__/roomMembership.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "bun:test";
+import { CloseCode, CloseReason } from "@shared/types";
+import { ConnectionManager } from "../connectionManager";
+import { DisconnectManager } from "../disconnectManager";
+import { InMemoryRoomManager } from "../roomManager";
+import { createRoomMembership } from "../roomMembership";
+import { fakeScheduler, fakeSocket, recordingBroadcaster } from "./testDoubles";
+
+const GRACE_MS = 30_000;
+
+function setup() {
+  const roomManager = new InMemoryRoomManager();
+  const connectionManager = new ConnectionManager();
+  const { scheduler, advance, pendingCount } = fakeScheduler();
+  const disconnectManager = new DisconnectManager(scheduler);
+  const { broadcaster, calls } = recordingBroadcaster();
+  const membership = createRoomMembership({
+    roomManager,
+    connectionManager,
+    disconnectManager,
+    broadcaster,
+    gracePeriodMs: GRACE_MS,
+  });
+
+  /** Open a socket for a member and route its close back through depart. */
+  function connect(username: string, role?: "voter" | "spectator") {
+    const ws = fakeSocket("room1", username);
+    if (role) ws.data.role = role;
+    ws.onClose = (code, reason) => membership.depart(ws, code, reason);
+    membership.arrive(ws);
+    return ws;
+  }
+
+  const types = () => calls.map((call) => call.msg.type);
+
+  return {
+    roomManager,
+    connectionManager,
+    disconnectManager,
+    membership,
+    calls,
+    types,
+    connect,
+    advance,
+    pendingCount,
+    reset: () => calls.splice(0, calls.length),
+  };
+}
+
+describe("roomMembership", () => {
+  describe("arrive", () => {
+    test("a first join creates the room, registers the socket, and snapshots back", () => {
+      const { roomManager, connectionManager, calls, connect } = setup();
+
+      const admin = connect("admin");
+
+      expect(roomManager.isUserInRoom("room1", "admin")).toBe(true);
+      expect(roomManager.getAdmin("room1")).toBe("admin");
+      expect(connectionManager.isConnected("room1", "admin")).toBe(true);
+      expect(admin.subscribed).toEqual(["room1"]);
+      expect(calls).toEqual([
+        {
+          to: "roomExcept",
+          sender: admin,
+          msg: { type: "userJoined", data: { username: "admin", role: "voter" } },
+        },
+        { to: "reply", ws: admin, msg: expect.objectContaining({ type: "joinRoomSuccess" }) },
+      ]);
+    });
+
+    test("the announced role comes from room state, not the query param", () => {
+      const { calls, connect } = setup();
+      connect("admin");
+
+      connect("watcher", "spectator");
+
+      expect(calls.at(-2)).toMatchObject({
+        msg: { type: "userJoined", data: { username: "watcher", role: "spectator" } },
+      });
+    });
+
+    test("a duplicate username is closed with UsernameTaken and never registered", () => {
+      const { connectionManager, membership, calls, connect, reset } = setup();
+      const original = connect("admin");
+      reset();
+
+      const dupe = fakeSocket("room1", "admin");
+      membership.arrive(dupe);
+
+      expect(dupe.closed?.code).toBe(CloseCode.UsernameTaken);
+      expect(dupe.subscribed).toEqual([]);
+      // The original holder keeps the name and the connection.
+      expect(connectionManager.getConnection("room1", "admin")).toBe(original);
+      expect(calls).toEqual([]);
+    });
+
+    test("a reconnect into a destroyed room is treated as a fresh join", () => {
+      const { roomManager, disconnectManager, membership, connect, reset } = setup();
+      const admin = connect("admin");
+      const voter = connect("voter");
+
+      // voter drops into the grace period, then the admin closes the room.
+      voter.close(1006, "");
+      admin.close(1000, CloseReason.UserLeft);
+      expect(roomManager.roomExists("room1")).toBe(false);
+
+      // Force the state the ordering constraint normally rules out: a
+      // stale grace entry for a room that is gone.
+      disconnectManager.markDisconnected("room1", "voter", () => {});
+      reset();
+
+      const returning = fakeSocket("room1", "voter");
+      membership.arrive(returning);
+
+      expect(roomManager.roomExists("room1")).toBe(true);
+      expect(roomManager.getAdmin("room1")).toBe("voter");
+      expect(disconnectManager.isDisconnected("room1", "voter")).toBe(false);
+    });
+  });
+
+  describe("depart", () => {
+    test("a deliberate leave drops the member and tells the room", () => {
+      const { roomManager, connectionManager, calls, connect, reset } = setup();
+      connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      voter.close(1000, CloseReason.UserLeft);
+
+      expect(roomManager.isUserInRoom("room1", "voter")).toBe(false);
+      expect(connectionManager.isConnected("room1", "voter")).toBe(false);
+      expect(calls).toEqual([
+        { to: "room", roomId: "room1", msg: { type: "userLeft", data: { username: "voter" } } },
+      ]);
+    });
+
+    test("an unexpected drop announces a disconnect and starts the grace period", () => {
+      const { roomManager, calls, connect, reset, pendingCount } = setup();
+      connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      voter.close(1006, "");
+
+      // Still on the roster — absent, not gone.
+      expect(roomManager.isUserInRoom("room1", "voter")).toBe(true);
+      expect(pendingCount()).toBe(1);
+      expect(calls).toEqual([
+        {
+          to: "room",
+          roomId: "room1",
+          msg: { type: "userDisconnected", data: { username: "voter" } },
+        },
+      ]);
+    });
+
+    test("the grace period expiring removes the member and announces userLeft", () => {
+      const { roomManager, calls, connect, reset, advance } = setup();
+      connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      voter.close(1006, "");
+      reset();
+
+      advance(GRACE_MS - 1);
+      expect(calls).toEqual([]);
+      expect(roomManager.isUserInRoom("room1", "voter")).toBe(true);
+
+      advance(1);
+      expect(roomManager.isUserInRoom("room1", "voter")).toBe(false);
+      expect(calls).toEqual([
+        { to: "room", roomId: "room1", msg: { type: "userLeft", data: { username: "voter" } } },
+      ]);
+    });
+
+    test("reconnecting before expiry cancels the timer and replays the snapshot", () => {
+      const { roomManager, connectionManager, membership, calls, connect, reset, advance } =
+        setup();
+      connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      voter.close(1006, "");
+      reset();
+
+      const returning = fakeSocket("room1", "voter");
+      membership.arrive(returning);
+
+      expect(connectionManager.isConnected("room1", "voter")).toBe(true);
+      expect(calls).toEqual([
+        { to: "reply", ws: returning, msg: expect.objectContaining({ type: "joinRoomSuccess" }) },
+        {
+          to: "roomExcept",
+          sender: returning,
+          msg: { type: "userReconnected", data: { username: "voter" } },
+        },
+      ]);
+
+      // The cancelled timer must not fire later.
+      reset();
+      advance(GRACE_MS * 2);
+      expect(calls).toEqual([]);
+      expect(roomManager.isUserInRoom("room1", "voter")).toBe(true);
+    });
+
+    test("the admin leaving closes the room, whatever reason the client sent", () => {
+      const { roomManager, calls, connect, reset } = setup();
+      const admin = connect("admin");
+      connect("voter");
+      reset();
+
+      // Deliberate leave: the admin branch must still win over "left".
+      admin.close(1000, CloseReason.UserLeft);
+
+      expect(roomManager.roomExists("room1")).toBe(false);
+      expect(calls).toEqual([
+        {
+          to: "room",
+          roomId: "room1",
+          msg: { type: "roomClosed", data: { reason: "Admin left the room" } },
+        },
+      ]);
+    });
+
+    test("the admin leaving clears pending grace timers before the room goes", () => {
+      const { calls, connect, reset, advance, pendingCount } = setup();
+      const admin = connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      voter.close(1006, "");
+      expect(pendingCount()).toBe(1);
+
+      admin.close(1006, "");
+      expect(pendingCount()).toBe(0);
+      reset();
+
+      // Nothing fires against the destroyed room.
+      advance(GRACE_MS * 2);
+      expect(calls).toEqual([]);
+    });
+
+    test("a UsernameTaken close unwinds nothing", () => {
+      const { connectionManager, membership, calls, connect, reset } = setup();
+      connect("admin");
+      reset();
+
+      const dupe = fakeSocket("room1", "admin");
+      membership.arrive(dupe);
+      reset();
+
+      membership.depart(dupe, CloseCode.UsernameTaken, "Username is already taken");
+
+      // The original holder keeps their connection and their membership.
+      expect(connectionManager.isConnected("room1", "admin")).toBe(true);
+      expect(calls).toEqual([]);
+    });
+
+    test("an evicted member's close is silent — evict already told the room", () => {
+      const { membership, calls, connect, reset } = setup();
+      connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      membership.evict("room1", "admin", "voter");
+      const afterEvict = calls.length;
+
+      // The socket close fires depart; it must not announce a second time.
+      voter.close(1000, CloseReason.RemovedByAdmin);
+
+      expect(calls.length).toBe(afterEvict);
+    });
+  });
+
+  describe("evict", () => {
+    test("removes a connected member: notify them, close them, tell the room", () => {
+      const { roomManager, connectionManager, membership, calls, connect, reset } = setup();
+      connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      membership.evict("room1", "admin", "voter");
+
+      expect(roomManager.isUserInRoom("room1", "voter")).toBe(false);
+      expect(voter.closed).toEqual({ code: 1000, reason: CloseReason.RemovedByAdmin });
+      expect(connectionManager.isConnected("room1", "voter")).toBe(false);
+      expect(calls).toEqual([
+        {
+          to: "user",
+          roomId: "room1",
+          username: "voter",
+          msg: { type: "youWereRemoved", data: { removedBy: "admin" } },
+        },
+        {
+          to: "room",
+          roomId: "room1",
+          msg: {
+            type: "participantRemoved",
+            data: { removedBy: "admin", participant: "voter" },
+          },
+        },
+      ]);
+    });
+
+    test("evicting a member inside the grace period cancels their timer", () => {
+      const { roomManager, membership, calls, connect, reset, advance, pendingCount } = setup();
+      connect("admin");
+      const voter = connect("voter");
+      reset();
+
+      voter.close(1006, "");
+      expect(pendingCount()).toBe(1);
+      reset();
+
+      membership.evict("room1", "admin", "voter");
+
+      expect(roomManager.isUserInRoom("room1", "voter")).toBe(false);
+      expect(pendingCount()).toBe(0);
+      // The room hears about it now, not 30s from now.
+      expect(calls).toEqual([
+        {
+          to: "room",
+          roomId: "room1",
+          msg: {
+            type: "participantRemoved",
+            data: { removedBy: "admin", participant: "voter" },
+          },
+        },
+      ]);
+
+      // And the cancelled timer never reports a stale userLeft.
+      reset();
+      advance(GRACE_MS * 2);
+      expect(calls).toEqual([]);
+    });
+
+    test("throws when the actor is not the admin, leaving the roster untouched", () => {
+      const { roomManager, membership, calls, connect, reset } = setup();
+      connect("admin");
+      connect("voter");
+      reset();
+
+      expect(() => membership.evict("room1", "voter", "admin")).toThrow(
+        "Only the admin can remove participants",
+      );
+      expect(roomManager.isUserInRoom("room1", "admin")).toBe(true);
+      expect(calls).toEqual([]);
+    });
+
+    test("throws when the target is not in the room", () => {
+      const { membership, connect, reset } = setup();
+      connect("admin");
+      reset();
+
+      expect(() => membership.evict("room1", "admin", "ghost")).toThrow(
+        "Participant not found in room",
+      );
+    });
+  });
+});

--- a/backend/src/__tests__/roomMembership.test.ts
+++ b/backend/src/__tests__/roomMembership.test.ts
@@ -241,6 +241,31 @@ describe("roomMembership", () => {
       expect(calls).toEqual([]);
     });
 
+    test("an absent admin's grace period expiring closes the room", () => {
+      // transferAdmin can hand the role to a member who is currently in
+      // the grace period, so the expiry path has to be able to end the
+      // session — not just announce a userLeft into a room that is gone.
+      const { roomManager, membership, calls, connect, reset, advance } = setup();
+      const admin = connect("admin");
+      const voter = connect("voter");
+
+      voter.close(1006, "");
+      roomManager.transferAdmin("room1", "admin", "voter");
+      admin.close(1000, CloseReason.UserLeft);
+      reset();
+
+      advance(GRACE_MS);
+
+      expect(roomManager.roomExists("room1")).toBe(false);
+      expect(calls).toEqual([
+        {
+          to: "room",
+          roomId: "room1",
+          msg: { type: "roomClosed", data: { reason: "Admin left the room" } },
+        },
+      ]);
+    });
+
     test("a UsernameTaken close unwinds nothing", () => {
       const { connectionManager, membership, calls, connect, reset } = setup();
       connect("admin");

--- a/backend/src/__tests__/server.test.ts
+++ b/backend/src/__tests__/server.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { ServerMessage } from "@shared/types";
+
+/**
+ * The one suite that drives the real entrypoint: Bun's fetch handler, the
+ * upgrade, and a live socket. Everything below the transport has its own
+ * unit tests — what only shows up here is the wiring, and whether the
+ * HTTP probe and the socket agree on what a room is called.
+ */
+
+// Must be set before importing index.ts: Bun.serve reads it at call time.
+process.env.PORT = "0";
+
+let baseUrl: string;
+let stop: () => void;
+
+beforeAll(async () => {
+  const { server } = await import("../index");
+  baseUrl = `http://${server.hostname}:${server.port}`;
+  stop = () => server.stop(true);
+});
+
+afterAll(() => stop());
+
+function wsUrl(params: Record<string, string>): string {
+  const url = new URL(baseUrl.replace("http:", "ws:"));
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+  return url.toString();
+}
+
+/** Open a socket and resolve once the join snapshot lands. */
+function join(params: Record<string, string>) {
+  return new Promise<{ socket: WebSocket; messages: ServerMessage[] }>((resolve, reject) => {
+    const socket = new WebSocket(wsUrl(params));
+    const messages: ServerMessage[] = [];
+    const timer = setTimeout(() => reject(new Error("timed out waiting for joinRoomSuccess")), 2000);
+
+    socket.onmessage = (event) => {
+      const msg = JSON.parse(event.data as string) as ServerMessage;
+      messages.push(msg);
+      if (msg.type === "joinRoomSuccess") {
+        clearTimeout(timer);
+        resolve({ socket, messages });
+      }
+    };
+    socket.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error("socket error"));
+    };
+  });
+}
+
+const probe = (id: string) => fetch(`${baseUrl}/rooms/${id}`);
+
+describe("server", () => {
+  describe("room existence probe", () => {
+    test("reports a room that has never existed", async () => {
+      const response = await probe("no-such-room");
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ exists: false, deck: null });
+    });
+
+    test("sends CORS headers so the SPA can read the answer cross-origin", async () => {
+      const response = await probe("no-such-room");
+
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    });
+
+    test("reports a live room and the deck it was created with", async () => {
+      const { socket } = await join({ roomId: "probe-live", username: "admin", deck: "tshirt" });
+
+      const response = await probe("probe-live");
+      expect(await response.json()).toEqual({ exists: true, deck: "tshirt" });
+
+      socket.close();
+    });
+
+    test("malformed percent-encoding answers the probe instead of failing", async () => {
+      const response = await probe("%E0%A4%A");
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ exists: false, deck: null });
+    });
+  });
+
+  describe("room id normalization", () => {
+    test("a room created in one casing is found by the probe in another", async () => {
+      const { socket } = await join({ roomId: "Sprint42", username: "admin" });
+
+      // The seed-script scenario: created uppercase, probed lowercase.
+      expect(await (await probe("sprint42")).json()).toMatchObject({ exists: true });
+      expect(await (await probe("SPRINT42")).json()).toMatchObject({ exists: true });
+
+      socket.close();
+    });
+
+    test("two clients spelling the room differently land in the same room", async () => {
+      const first = await join({ roomId: "Casing-Test", username: "alice" });
+      const second = await join({ roomId: "  casing-test  ", username: "bob" });
+
+      // bob's snapshot lists alice, so they are in one room and not two.
+      const snapshot = second.messages.find((msg) => msg.type === "joinRoomSuccess");
+      expect(snapshot).toBeDefined();
+      if (snapshot?.type === "joinRoomSuccess") {
+        expect(Object.keys(snapshot.data.participants).sort()).toEqual(["alice", "bob"]);
+        expect(snapshot.data.admin).toBe("alice");
+      }
+
+      first.socket.close();
+      second.socket.close();
+    });
+  });
+
+  describe("upgrade", () => {
+    test("rejects a connection with no username", async () => {
+      const response = await fetch(`${baseUrl}/?roomId=room1`);
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("Username is required");
+    });
+
+    test("rejects a connection with no room id", async () => {
+      const response = await fetch(`${baseUrl}/?username=alice`);
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("Room ID is required");
+    });
+
+    test("rejects a room id that normalizes to nothing", async () => {
+      const response = await fetch(`${baseUrl}/?username=alice&roomId=${encodeURIComponent("   ")}`);
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("Room ID is required");
+    });
+  });
+});

--- a/backend/src/__tests__/testDoubles.ts
+++ b/backend/src/__tests__/testDoubles.ts
@@ -1,0 +1,103 @@
+import type { ServerWebSocket } from "bun";
+import type { ServerMessage, WebSocketData } from "@shared/types";
+import type { RoomBroadcaster } from "../roomBroadcaster";
+import type { Scheduler } from "../disconnectManager";
+
+type Socket = ServerWebSocket<WebSocketData>;
+
+export type FakeSocket = Socket & {
+  sent: string[];
+  closed?: { code?: number; reason?: string };
+  subscribed: string[];
+  /** Fires when close() is called, standing in for Bun's close callback. */
+  onClose?: (code: number, reason: string) => void;
+};
+
+export function fakeSocket(roomId: string, username: string): FakeSocket {
+  const socket = {
+    data: { roomId, username },
+    sent: [] as string[],
+    subscribed: [] as string[],
+    closed: undefined as { code?: number; reason?: string } | undefined,
+    onClose: undefined as ((code: number, reason: string) => void) | undefined,
+    send(raw: string) {
+      socket.sent.push(raw);
+    },
+    subscribe(topic: string) {
+      socket.subscribed.push(topic);
+    },
+    close(code?: number, reason?: string) {
+      socket.closed = { code, reason };
+      socket.onClose?.(code ?? 1000, reason ?? "");
+    },
+  };
+  return socket as unknown as FakeSocket;
+}
+
+export type EachMemberCall = {
+  to: "eachMember";
+  roomId: string;
+  build: (username: string) => ServerMessage;
+};
+
+export type BroadcastCall =
+  | { to: "room"; roomId: string; msg: ServerMessage }
+  | { to: "roomExcept"; sender: Socket; msg: ServerMessage }
+  | { to: "user"; roomId: string; username: string; msg: ServerMessage }
+  | EachMemberCall
+  | { to: "reply"; ws: Socket; msg: ServerMessage };
+
+/** The seam's second adapter: records every broadcast instead of sending. */
+export function recordingBroadcaster() {
+  const calls: BroadcastCall[] = [];
+  const broadcaster: RoomBroadcaster = {
+    toRoom: (roomId, msg) => calls.push({ to: "room", roomId, msg }),
+    toRoomExcept: (sender, msg) => calls.push({ to: "roomExcept", sender, msg }),
+    toUser: (roomId, username, msg) => calls.push({ to: "user", roomId, username, msg }),
+    toEachMember: (roomId, build) => calls.push({ to: "eachMember", roomId, build }),
+    reply: (ws, msg) => calls.push({ to: "reply", ws, msg }),
+  };
+  return { broadcaster, calls };
+}
+
+/** The personalized payload a given member would have received. */
+export function payloadFor(call: BroadcastCall | undefined, username: string): ServerMessage {
+  if (!call || call.to !== "eachMember") {
+    throw new Error(`Expected an eachMember call, got ${call?.to}`);
+  }
+  return call.build(username);
+}
+
+/**
+ * The DisconnectManager's scheduling seam, driven by hand. Grace-period
+ * expiry is asserted by advancing time, not by sleeping.
+ */
+export function fakeScheduler() {
+  let nextId = 1;
+  const pending = new Map<number, { runAt: number; callback: () => void }>();
+  let now = 0;
+
+  const scheduler: Scheduler = {
+    schedule(callback, delayMs) {
+      const id = nextId++;
+      pending.set(id, { runAt: now + delayMs, callback });
+      return id;
+    },
+    cancel(timer) {
+      pending.delete(timer as number);
+    },
+  };
+
+  /** Advance the clock, firing anything that comes due. */
+  function advance(ms: number): void {
+    now += ms;
+    for (const [id, entry] of [...pending]) {
+      if (entry.runAt <= now) {
+        pending.delete(id);
+        entry.callback();
+      }
+    }
+  }
+
+  return { scheduler, advance, pendingCount: () => pending.size };
+}

--- a/backend/src/clientMessageHandler.ts
+++ b/backend/src/clientMessageHandler.ts
@@ -7,8 +7,8 @@ import {
 } from "@shared/types";
 import type { RoomManager } from "./roomManager";
 import type { RoomBroadcaster } from "./roomBroadcaster";
-import type { ConnectionManager } from "./connectionManager";
 import type { ReactionRateLimiter } from "./reactionRateLimiter";
+import type { RoomMembership } from "./roomMembership";
 import { userVotedMessage, voteStatusMessage } from "./roomSnapshots";
 import { logger } from "./logger";
 
@@ -16,9 +16,9 @@ type Socket = ServerWebSocket<WebSocketData>;
 
 export type ClientMessageHandlerDeps = {
   roomManager: RoomManager;
-  connectionManager: ConnectionManager;
   broadcaster: RoomBroadcaster;
   rateLimiter: ReactionRateLimiter;
+  membership: RoomMembership;
 };
 
 /**
@@ -28,7 +28,7 @@ export type ClientMessageHandlerDeps = {
  * in and assert recorded broadcasts out.
  */
 export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
-  const { roomManager, connectionManager, broadcaster, rateLimiter } = deps;
+  const { roomManager, broadcaster, rateLimiter, membership } = deps;
 
   function parseMessage(raw: string): ClientMessage {
     try {
@@ -128,22 +128,11 @@ export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
         const participantToRemove = msg.data.participant;
         if (!participantToRemove) break;
 
-        roomManager.removeParticipant(roomId, username, participantToRemove);
-
-        // A member in the disconnect grace period has no live connection;
-        // in that case nothing is broadcast and the room learns of the
-        // removal when the grace period expires (userLeft).
-        if (!connectionManager.isConnected(roomId, participantToRemove)) break;
-
-        broadcaster.toUser(roomId, participantToRemove, {
-          type: "youWereRemoved",
-          data: { removedBy: username },
-        });
-        connectionManager.closeConnection(roomId, participantToRemove, "Removed by admin");
-        broadcaster.toRoom(roomId, {
-          type: "participantRemoved",
-          data: { removedBy: username, participant: participantToRemove },
-        });
+        // Removal is a membership transition: it touches the roster, the
+        // connection registry and any pending grace entry, so it lives
+        // behind that seam. Authorization failures throw through to the
+        // error reply below.
+        membership.evict(roomId, username, participantToRemove);
         break;
       }
 

--- a/backend/src/disconnectManager.ts
+++ b/backend/src/disconnectManager.ts
@@ -1,14 +1,32 @@
 type DisconnectEntry = {
-  timer: ReturnType<typeof setTimeout>;
-  onExpiry: () => void;
+  timer: unknown;
 };
 
+/**
+ * The scheduling seam. Production passes real timers; tests pass a fake
+ * clock so grace-period expiry is asserted by advancing time rather than
+ * by sleeping. Mirrors the injectable clock in ReactionRateLimiter.
+ */
+export type Scheduler = {
+  schedule(callback: () => void, delayMs: number): unknown;
+  cancel(timer: unknown): void;
+};
+
+const realTimers: Scheduler = {
+  schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+  cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+};
+
+/**
+ * Who is inside the disconnect grace period: a member of the room roster
+ * with no live socket. Timer handles never escape — callers mark, cancel,
+ * or ask, and the entry cleans itself up before onExpiry runs so the
+ * callback sees consistent state.
+ */
 export class DisconnectManager {
   private disconnected = new Map<string, Map<string, DisconnectEntry>>();
 
-  private getKey(roomId: string, username: string): string {
-    return `${roomId}:${username}`;
-  }
+  constructor(private readonly scheduler: Scheduler = realTimers) {}
 
   markDisconnected(
     roomId: string,
@@ -20,7 +38,7 @@ export class DisconnectManager {
       this.disconnected.set(roomId, new Map());
     }
 
-    const timer = setTimeout(() => {
+    const timer = this.scheduler.schedule(() => {
       this.disconnected.get(roomId)?.delete(username);
       if (this.disconnected.get(roomId)?.size === 0) {
         this.disconnected.delete(roomId);
@@ -28,7 +46,7 @@ export class DisconnectManager {
       onExpiry();
     }, gracePeriodMs);
 
-    this.disconnected.get(roomId)!.set(username, { timer, onExpiry });
+    this.disconnected.get(roomId)!.set(username, { timer });
   }
 
   cancelDisconnect(roomId: string, username: string): boolean {
@@ -38,7 +56,7 @@ export class DisconnectManager {
     const entry = roomDisconnects.get(username);
     if (!entry) return false;
 
-    clearTimeout(entry.timer);
+    this.scheduler.cancel(entry.timer);
     roomDisconnects.delete(username);
 
     if (roomDisconnects.size === 0) {
@@ -57,7 +75,7 @@ export class DisconnectManager {
     if (!roomDisconnects) return;
 
     for (const entry of roomDisconnects.values()) {
-      clearTimeout(entry.timer);
+      this.scheduler.cancel(entry.timer);
     }
 
     this.disconnected.delete(roomId);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,17 +6,12 @@ import { logger } from "./logger";
 import { ReactionRateLimiter } from "./reactionRateLimiter";
 import { BunRoomBroadcaster } from "./roomBroadcaster";
 import { createClientMessageHandler } from "./clientMessageHandler";
-import { joinRoomSuccessMessage } from "./roomSnapshots";
+import { createRoomMembership } from "./roomMembership";
 
 const connectionManager = new ConnectionManager();
 const roomManager = new InMemoryRoomManager();
 const disconnectManager = new DisconnectManager();
 const reactionRateLimiter = new ReactionRateLimiter();
-
-const ErrorCodes = {
-  Unknown: 4000,
-  UsernameTaken: 4001,
-} as const;
 
 const server = Bun.serve<WebSocketData>({
   fetch(req, server) {
@@ -58,106 +53,13 @@ const server = Bun.serve<WebSocketData>({
     idleTimeout: 960,
     sendPings: true,
     open(ws) {
-      const { roomId, username } = ws.data;
-
-      // Check if this is a reconnection
-      if (disconnectManager.isDisconnected(roomId, username)) {
-        disconnectManager.cancelDisconnect(roomId, username);
-
-        ws.subscribe(roomId);
-        connectionManager.registerConnection(roomId, username, ws);
-
-        logger.websocket(`User reconnected`, { roomId, username });
-
-        // Send current room state to reconnected user
-        broadcaster.reply(ws, joinRoomSuccessMessage(roomId, roomManager, username));
-
-        // Notify others that user reconnected
-        broadcaster.toRoomExcept(ws, { type: "userReconnected", data: { username } });
-        return;
-      }
-
-      // Normal join flow
-      try {
-        roomManager.joinRoom(roomId, username, ws.data.deck, ws.data.role);
-      } catch (error: any) {
-        ws.close(ErrorCodes.UsernameTaken, error.message);
-        return;
-      }
-
-      ws.subscribe(roomId);
-      connectionManager.registerConnection(roomId, username, ws);
-
-      logger.websocket(`Connection opened`, { roomId, username });
-
-      // Role comes from room state, not the query param, so the broadcast
-      // matches what joinRoom actually recorded.
-      broadcaster.toRoomExcept(ws, {
-        type: "userJoined",
-        data: { username, role: roomManager.isSpectator(roomId, username) ? "spectator" : "voter" },
-      });
-
-      broadcaster.reply(ws, joinRoomSuccessMessage(roomId, roomManager, username));
+      membership.arrive(ws);
     },
     message(ws, message) {
       clientMessages.handle(ws, message as string);
     },
     close(ws, code, reason) {
-      const { roomId, username } = ws.data;
-      if (!roomId || !username) return;
-
-      const log = code === 1000 ? logger.websocket : logger.error;
-      switch (code) {
-        case ErrorCodes.UsernameTaken:
-          logger.error(`Username taken`, { roomId, username, code, reason });
-          return;
-        default:
-          log(`Connection closed`, { roomId, username, code, reason });
-      }
-
-      // Remove the connection
-      connectionManager.removeConnection(roomId, username);
-
-      // Admin disconnect → destroy room immediately
-      if (roomManager.isAdmin(roomId, username)) {
-        disconnectManager.clearRoom(roomId);
-        const { shouldDestroyRoom } = roomManager.leaveRoom(roomId, username);
-        if (shouldDestroyRoom) {
-          broadcaster.toRoom(roomId, {
-            type: "roomClosed",
-            data: { reason: "Admin left the room" },
-          });
-        }
-        return;
-      }
-
-      // User was removed by admin — already handled
-      if (reason === "Removed by admin") return;
-
-      // User intentionally left — no grace period
-      if (reason === "User left room") {
-        const { shouldDestroyRoom } = roomManager.leaveRoom(roomId, username);
-        if (!shouldDestroyRoom) {
-          broadcaster.toRoom(roomId, { type: "userLeft", data: { username } });
-        }
-        return;
-      }
-
-      // Unexpected disconnect — start grace period
-      logger.websocket(`User disconnected unexpectedly, starting grace period`, {
-        roomId,
-        username,
-      });
-      broadcaster.toRoom(roomId, { type: "userDisconnected", data: { username } });
-
-      disconnectManager.markDisconnected(roomId, username, () => {
-        // Grace period expired — remove the user
-        logger.websocket(`Grace period expired`, { roomId, username });
-        const { shouldDestroyRoom } = roomManager.leaveRoom(roomId, username);
-        if (!shouldDestroyRoom) {
-          broadcaster.toRoom(roomId, { type: "userLeft", data: { username } });
-        }
-      });
+      membership.depart(ws, code, reason);
     },
   },
 });
@@ -166,11 +68,17 @@ const server = Bun.serve<WebSocketData>({
 // server handle. Safe: the websocket callbacks above can't fire until this
 // synchronous startup block finishes.
 const broadcaster = new BunRoomBroadcaster(server, connectionManager);
-const clientMessages = createClientMessageHandler({
+const membership = createRoomMembership({
   roomManager,
   connectionManager,
+  disconnectManager,
+  broadcaster,
+});
+const clientMessages = createClientMessageHandler({
+  roomManager,
   broadcaster,
   rateLimiter: reactionRateLimiter,
+  membership,
 });
 
 console.log(`Listening on ${server.hostname}:${server.port}`);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,7 +13,9 @@ const roomManager = new InMemoryRoomManager();
 const disconnectManager = new DisconnectManager();
 const reactionRateLimiter = new ReactionRateLimiter();
 
-const server = Bun.serve<WebSocketData>({
+// Exported so an integration test can bind an ephemeral port (PORT=0)
+// and stop the server afterwards. Production still runs `bun index.ts`.
+export const server = Bun.serve<WebSocketData>({
   fetch(req, server) {
     const url = new URL(req.url);
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import { isDeckId, isParticipantRole, type WebSocketData } from "@shared/types";
+import { isDeckId, isParticipantRole, normalizeRoomId, type WebSocketData } from "@shared/types";
 import { InMemoryRoomManager } from "./roomManager";
 import { ConnectionManager } from "./connectionManager";
 import { DisconnectManager } from "./disconnectManager";
@@ -26,7 +26,7 @@ const server = Bun.serve<WebSocketData>({
       // can't name a room, so answer the probe instead of 500ing.
       let id = "";
       try {
-        id = decodeURIComponent(roomsMatch[1]).toLowerCase();
+        id = normalizeRoomId(decodeURIComponent(roomsMatch[1]));
       } catch {}
       const exists = id !== "" && roomManager.roomExists(id);
       return Response.json(
@@ -35,12 +35,16 @@ const server = Bun.serve<WebSocketData>({
       );
     }
 
-    const roomId = url.searchParams.get("roomId");
+    const rawRoomId = url.searchParams.get("roomId");
     const username = url.searchParams.get("username");
     const deckParam = url.searchParams.get("deck");
     const deck = deckParam && isDeckId(deckParam) ? deckParam : undefined;
     const roleParam = url.searchParams.get("role");
     const role = roleParam && isParticipantRole(roleParam) ? roleParam : undefined;
+
+    // Normalized here so the socket and the probe above agree, whatever
+    // the client sent. Everything downstream reads ws.data.roomId.
+    const roomId = rawRoomId ? normalizeRoomId(rawRoomId) : "";
 
     if (!username) return new Response("Username is required", { status: 400 });
     if (!roomId) return new Response("Room ID is required", { status: 400 });

--- a/backend/src/roomManager.ts
+++ b/backend/src/roomManager.ts
@@ -24,7 +24,8 @@ export interface RoomManager {
   transferAdmin(roomId: string, currentAdmin: string, newAdmin: string): void;
   isAdmin(roomId: string, username: string): boolean;
   getAdmin(roomId: string): string | null;
-  leaveRoom(roomId: string, username: string): { shouldDestroyRoom: boolean };
+  /** Drop a member; `destroyed` means the room is gone and members must be told. */
+  leaveRoom(roomId: string, username: string): { destroyed: boolean };
   submitVote(roomId: string, username: string, vote: Vote): void;
   setVoteVisibility(roomId: string, username: string, revealed: boolean): void;
   clearVotes(roomId: string, username: string): void;
@@ -98,21 +99,27 @@ export class InMemoryRoomManager implements RoomManager {
     return room ? room.admin : null;
   }
 
-  leaveRoom(roomId: string, username: string) {
+  /**
+   * Drop a member from the room. The room itself goes when its admin
+   * leaves — and only then: every other member can leave without ending
+   * the session, and the admin is necessarily the last one standing
+   * (`transferAdmin` moves the role, it never vacates it).
+   *
+   * `destroyed` says exactly that the room is gone, so callers must tell
+   * the remaining members. It is not a proxy for "was this the admin".
+   */
+  leaveRoom(roomId: string, username: string): { destroyed: boolean } {
     const room = this.rooms.get(roomId);
-    if (!room) return { shouldDestroyRoom: false };
+    if (!room) return { destroyed: false };
 
     room.users.delete(username);
     room.spectators.delete(username);
     room.votes.delete(username);
 
-    const isAdmin = room.admin === username;
+    const destroyed = room.admin === username;
+    if (destroyed) this.rooms.delete(roomId);
 
-    if (room.users.size === 0 || isAdmin) {
-      this.rooms.delete(roomId);
-    }
-
-    return { shouldDestroyRoom: isAdmin };
+    return { destroyed };
   }
 
   submitVote(roomId: string, username: string, vote: Vote) {

--- a/backend/src/roomMembership.ts
+++ b/backend/src/roomMembership.ts
@@ -1,0 +1,205 @@
+import type { ServerWebSocket } from "bun";
+import { CloseCode, CloseReason, type WebSocketData } from "@shared/types";
+import type { RoomManager } from "./roomManager";
+import type { RoomBroadcaster } from "./roomBroadcaster";
+import type { ConnectionManager } from "./connectionManager";
+import type { DisconnectManager } from "./disconnectManager";
+import { joinRoomSuccessMessage } from "./roomSnapshots";
+import { logger } from "./logger";
+
+type Socket = ServerWebSocket<WebSocketData>;
+
+export type RoomMembershipDeps = {
+  roomManager: RoomManager;
+  connectionManager: ConnectionManager;
+  disconnectManager: DisconnectManager;
+  broadcaster: RoomBroadcaster;
+  /** Overridable so tests can assert expiry without a long fake advance. */
+  gracePeriodMs?: number;
+};
+
+/**
+ * How a member enters and leaves a room. Membership (a name on the room
+ * roster) and presence (a live socket) are separate facts, and the grace
+ * period is exactly the state where they disagree — keeping both here is
+ * what lets the roster, the connection registry and the disconnect
+ * registry stay consistent without callers sequencing them by hand.
+ *
+ * Charter: membership transitions only. Voting, decks and reactions are
+ * the ClientMessageHandler's business.
+ */
+export function createRoomMembership(deps: RoomMembershipDeps) {
+  const {
+    roomManager,
+    connectionManager,
+    disconnectManager,
+    broadcaster,
+    gracePeriodMs = 30_000,
+  } = deps;
+
+  /**
+   * Why a socket closed. Derived from the close frame *and* room state —
+   * admin departure outranks whatever reason the client sent, which is
+   * why this can't be a pure decode of (code, reason).
+   */
+  type DepartureReason = "usernameTaken" | "adminLeft" | "evicted" | "left" | "lost";
+
+  function classify(roomId: string, username: string, code: number, reason: string): DepartureReason {
+    if (code === CloseCode.UsernameTaken) return "usernameTaken";
+    // Checked before the reason strings: an admin who leaves deliberately
+    // still closes the room, so their "User left room" must not win here.
+    if (roomManager.isAdmin(roomId, username)) return "adminLeft";
+    if (reason === CloseReason.RemovedByAdmin) return "evicted";
+    if (reason === CloseReason.UserLeft) return "left";
+    return "lost";
+  }
+
+  /** Drop from the roster and tell the room, unless the room itself went. */
+  function removeAndAnnounce(roomId: string, username: string): void {
+    const { shouldDestroyRoom } = roomManager.leaveRoom(roomId, username);
+    if (!shouldDestroyRoom) {
+      broadcaster.toRoom(roomId, { type: "userLeft", data: { username } });
+    }
+  }
+
+  /**
+   * A socket opened for a member: either a reconnect inside the grace
+   * period, or a fresh join. The room-existence check matters because a
+   * reconnect into a destroyed room would otherwise try to snapshot a
+   * room that is gone; treating it as a fresh join recreates it.
+   */
+  function arrive(ws: Socket): void {
+    const { roomId, username } = ws.data;
+
+    if (disconnectManager.isDisconnected(roomId, username) && roomManager.roomExists(roomId)) {
+      disconnectManager.cancelDisconnect(roomId, username);
+
+      ws.subscribe(roomId);
+      connectionManager.registerConnection(roomId, username, ws);
+
+      logger.websocket(`User reconnected`, { roomId, username });
+
+      broadcaster.reply(ws, joinRoomSuccessMessage(roomId, roomManager, username));
+      broadcaster.toRoomExcept(ws, { type: "userReconnected", data: { username } });
+      return;
+    }
+
+    // A stale grace entry for a room that no longer exists would keep the
+    // member out of the fresh join below.
+    disconnectManager.cancelDisconnect(roomId, username);
+
+    try {
+      roomManager.joinRoom(roomId, username, ws.data.deck, ws.data.role);
+    } catch (error) {
+      ws.close(CloseCode.UsernameTaken, (error as Error).message);
+      return;
+    }
+
+    ws.subscribe(roomId);
+    connectionManager.registerConnection(roomId, username, ws);
+
+    logger.websocket(`Connection opened`, { roomId, username });
+
+    // Role comes from room state, not the query param, so the broadcast
+    // matches what joinRoom actually recorded.
+    broadcaster.toRoomExcept(ws, {
+      type: "userJoined",
+      data: { username, role: roomManager.isSpectator(roomId, username) ? "spectator" : "voter" },
+    });
+
+    broadcaster.reply(ws, joinRoomSuccessMessage(roomId, roomManager, username));
+  }
+
+  /** A socket closed. The reason decides whether the member is gone,
+   *  merely absent, or already accounted for. */
+  function depart(ws: Socket, code: number, reason: string): void {
+    const { roomId, username } = ws.data;
+    if (!roomId || !username) return;
+
+    const departure = classify(roomId, username, code, reason);
+
+    // The join was rejected before the connection was ever registered,
+    // so there is nothing to unwind.
+    if (departure === "usernameTaken") {
+      logger.error(`Username taken`, { roomId, username, code, reason });
+      return;
+    }
+
+    const log = code === 1000 ? logger.websocket : logger.error;
+    log(`Connection closed`, { roomId, username, code, reason });
+
+    connectionManager.removeConnection(roomId, username);
+
+    switch (departure) {
+      case "adminLeft":
+        // Grace timers must go before the room does, or they fire against
+        // a room that no longer exists.
+        disconnectManager.clearRoom(roomId);
+        if (roomManager.leaveRoom(roomId, username).shouldDestroyRoom) {
+          broadcaster.toRoom(roomId, {
+            type: "roomClosed",
+            data: { reason: "Admin left the room" },
+          });
+        }
+        return;
+
+      case "evicted":
+        // evict() already dropped them from the roster and told the room.
+        return;
+
+      case "left":
+        removeAndAnnounce(roomId, username);
+        return;
+
+      case "lost":
+        logger.websocket(`User disconnected unexpectedly, starting grace period`, {
+          roomId,
+          username,
+        });
+        broadcaster.toRoom(roomId, { type: "userDisconnected", data: { username } });
+
+        disconnectManager.markDisconnected(
+          roomId,
+          username,
+          () => {
+            logger.websocket(`Grace period expired`, { roomId, username });
+            removeAndAnnounce(roomId, username);
+          },
+          gracePeriodMs,
+        );
+        return;
+    }
+  }
+
+  /**
+   * The admin removes a member. Throws on an unauthorized or unknown
+   * target — the ClientMessageHandler turns that into an error reply.
+   *
+   * Cancelling any pending grace entry is what keeps a removed member
+   * from being announced twice: without it their timer still fires and
+   * reports a userLeft for someone already gone.
+   */
+  function evict(roomId: string, actor: string, target: string): void {
+    roomManager.removeParticipant(roomId, actor, target);
+    disconnectManager.cancelDisconnect(roomId, target);
+
+    // A member inside the grace period has no socket to notify or close,
+    // but the room still hears about it now rather than 30s from now.
+    if (connectionManager.isConnected(roomId, target)) {
+      broadcaster.toUser(roomId, target, {
+        type: "youWereRemoved",
+        data: { removedBy: actor },
+      });
+      connectionManager.closeConnection(roomId, target, CloseReason.RemovedByAdmin);
+    }
+
+    broadcaster.toRoom(roomId, {
+      type: "participantRemoved",
+      data: { removedBy: actor, participant: target },
+    });
+  }
+
+  return { arrive, depart, evict };
+}
+
+export type RoomMembership = ReturnType<typeof createRoomMembership>;

--- a/backend/src/roomMembership.ts
+++ b/backend/src/roomMembership.ts
@@ -54,12 +54,27 @@ export function createRoomMembership(deps: RoomMembershipDeps) {
     return "lost";
   }
 
-  /** Drop from the roster and tell the room, unless the room itself went. */
+  /**
+   * Drop from the roster and tell the room what happened to it. Losing
+   * the admin ends the session, so that case announces `roomClosed`
+   * instead of `userLeft` — including when the admin's grace period is
+   * what expired, which is reachable because `transferAdmin` can hand the
+   * role to a member who is currently absent.
+   */
   function removeAndAnnounce(roomId: string, username: string): void {
-    const { shouldDestroyRoom } = roomManager.leaveRoom(roomId, username);
-    if (!shouldDestroyRoom) {
+    const { destroyed } = roomManager.leaveRoom(roomId, username);
+
+    if (!destroyed) {
       broadcaster.toRoom(roomId, { type: "userLeft", data: { username } });
+      return;
     }
+
+    // Grace timers must never outlive the room they would fire against.
+    disconnectManager.clearRoom(roomId);
+    broadcaster.toRoom(roomId, {
+      type: "roomClosed",
+      data: { reason: "Admin left the room" },
+    });
   }
 
   /**
@@ -132,23 +147,14 @@ export function createRoomMembership(deps: RoomMembershipDeps) {
 
     switch (departure) {
       case "adminLeft":
-        // Grace timers must go before the room does, or they fire against
-        // a room that no longer exists.
-        disconnectManager.clearRoom(roomId);
-        if (roomManager.leaveRoom(roomId, username).shouldDestroyRoom) {
-          broadcaster.toRoom(roomId, {
-            type: "roomClosed",
-            data: { reason: "Admin left the room" },
-          });
-        }
+      case "left":
+        // One operation: leave the roster, tell the room. Whether that
+        // ends the session is the roster's answer, not the reason's.
+        removeAndAnnounce(roomId, username);
         return;
 
       case "evicted":
         // evict() already dropped them from the roster and told the room.
-        return;
-
-      case "left":
-        removeAndAnnounce(roomId, username);
         return;
 
       case "lost":

--- a/frontend/src/composables/useRecentRooms.ts
+++ b/frontend/src/composables/useRecentRooms.ts
@@ -1,5 +1,11 @@
 import { computed, ref, watch } from "vue";
-import { isDeckId, isParticipantRole, type DeckId, type ParticipantRole } from "@shared/types";
+import {
+  isDeckId,
+  isParticipantRole,
+  normalizeRoomId,
+  type DeckId,
+  type ParticipantRole,
+} from "@shared/types";
 
 export type RecentRoom = {
   id: string;
@@ -41,7 +47,7 @@ function getStoredRooms() {
  */
 export function rememberRoomDeck(roomId: string, deck: DeckId): void {
   const rooms = getStoredRooms();
-  const entry = rooms.find((room) => room.id.toLowerCase() === roomId.toLowerCase());
+  const entry = rooms.find((room) => normalizeRoomId(room.id) === normalizeRoomId(roomId));
   if (!entry || entry.deck === deck) return;
 
   entry.deck = deck;
@@ -70,7 +76,7 @@ export function useRecentRooms() {
     storedRooms.value = [
       room,
       ...storedRooms.value.filter(
-        (recentRoom) => recentRoom.id.toLowerCase() !== room.id.toLowerCase(),
+        (recentRoom) => normalizeRoomId(recentRoom.id) !== normalizeRoomId(room.id),
       ),
     ].slice(0, MAX_RECENT_ROOMS);
   }

--- a/frontend/src/composables/useRoomSession.ts
+++ b/frontend/src/composables/useRoomSession.ts
@@ -2,7 +2,13 @@ import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { storeToRefs } from "pinia";
 import { useToast } from "primevue/usetoast";
-import { decks, isDeckId, type DeckId, type ServerMessage } from "@shared/types";
+import {
+  decks,
+  isDeckId,
+  normalizeRoomId,
+  type DeckId,
+  type ServerMessage,
+} from "@shared/types";
 import { usernameKey } from "@/modules/constants";
 import {
   createRoomConnection,
@@ -59,7 +65,7 @@ export function useRoomSession(id: string) {
     );
   }
 
-  const roomId = computed(() => id?.toLowerCase() ?? "");
+  const roomId = computed(() => normalizeRoomId(id ?? ""));
   // Deck chosen at creation arrives as a `?deck=` route query; harmless
   // for joiners since the backend ignores it when the room exists.
   const pendingDeck = computed<DeckId | undefined>(() => {

--- a/frontend/src/modules/roomConnection.ts
+++ b/frontend/src/modules/roomConnection.ts
@@ -1,4 +1,11 @@
-import type { ClientMessage, DeckId, ReactionEmoji, ServerMessage } from "@shared/types";
+import {
+  CloseCode,
+  CloseReason,
+  type ClientMessage,
+  type DeckId,
+  type ReactionEmoji,
+  type ServerMessage,
+} from "@shared/types";
 
 export type ConnectionStatus = "connected" | "disconnected" | "reconnecting" | "failed";
 
@@ -115,10 +122,10 @@ export function createRoomConnection(config: RoomConnectionConfig): RoomConnecti
       if (intentionalClose) return;
 
       // Removed by admin comes with its own notification in the room view
-      if (event.reason === "Removed by admin") return;
+      if (event.reason === CloseReason.RemovedByAdmin) return;
 
       // Username taken — no reconnection
-      if (event.code === 4001) {
+      if (event.code === CloseCode.UsernameTaken) {
         onMessage({ type: "roomClosed", data: { reason: event.reason ?? "Username is taken" } });
         return;
       }
@@ -155,7 +162,7 @@ export function createRoomConnection(config: RoomConnectionConfig): RoomConnecti
       intentionalClose = true;
       clearReconnectTimer();
       reconnectAttempts = 0;
-      socket?.close(1000, "User left room");
+      socket?.close(1000, CloseReason.UserLeft);
       socket = null;
     },
     updateUrl: (url) => {

--- a/frontend/src/views/DeckChooserView.vue
+++ b/frontend/src/views/DeckChooserView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { decks, defaultDeckId, type DeckId } from "@shared/types";
+import { decks, defaultDeckId, normalizeRoomId, type DeckId } from "@shared/types";
 import DeckOptionCard from "@/components/DeckOptionCard.vue";
 import { useRecentRooms } from "@/composables/useRecentRooms";
 import { checkRoom } from "@/modules/api";
@@ -33,7 +33,7 @@ const isCreate = computed(() => props.mode === "create");
 // Role picked on the home form rides along as `?role=spectator` so the
 // create flow (home → chooser → room) doesn't lose it.
 const asSpectator = computed(() => isCreate.value && route.query.role === "spectator");
-const roomId = computed(() => props.id.toLowerCase());
+const roomId = computed(() => normalizeRoomId(props.id));
 const selected = ref<DeckId>(props.currentDeck ?? defaultDeckId);
 const deckList = Object.values(decks);
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
-import { decks, type DeckId, type ParticipantRole } from "@shared/types";
+import { decks, normalizeRoomId, type DeckId, type ParticipantRole } from "@shared/types";
 import PointCard from "@/components/PointCard.vue";
 import RoleToggle from "@/components/RoleToggle.vue";
 import type { RecentRoom } from "@/composables/useRecentRooms";
@@ -37,13 +37,13 @@ let checkToken = 0;
 watch(roomId, (value) => {
   resolvedAction.value = null;
   clearTimeout(debounceTimer);
-  const id = value.trim().toLowerCase();
+  const id = normalizeRoomId(value);
   if (!id) return;
 
   debounceTimer = setTimeout(async () => {
     const token = ++checkToken;
     const result = await checkRoom(id);
-    if (token !== checkToken || roomId.value.trim().toLowerCase() !== id) return;
+    if (token !== checkToken || normalizeRoomId(roomId.value) !== id) return;
     if (result) resolvedAction.value = result.exists ? "join" : "create";
   }, 400);
 });
@@ -77,7 +77,7 @@ async function submit() {
 
   const role = joinRole.value;
   const chooserQuery = role === "spectator" ? { role } : undefined;
-  const typedRoomId = roomId.value.trim().toLowerCase();
+  const typedRoomId = normalizeRoomId(roomId.value);
 
   // Empty Room ID → create with a generated one; a fresh random ID is
   // new, so no existence check needed. The recent-rooms entry is saved
@@ -108,7 +108,7 @@ function useRecentRoom(recentRoom: RecentRoom) {
   store.setUsername(username.value);
   // One click, no existence check: a live room ignores the deck param,
   // a dead one is recreated on the deck the user last saw there.
-  joinRoom(recentRoom.id.toLowerCase(), recentRoom.deck, recentRoom.role);
+  joinRoom(normalizeRoomId(recentRoom.id), recentRoom.deck, recentRoom.role);
 }
 
 const HOUR = 3_600_000;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -113,6 +113,32 @@ export type WebSocketData = {
   role?: ParticipantRole
 }
 
+// ── Close frame contract ──
+
+/**
+ * The close frame is part of the wire contract: the backend classifies a
+ * departure from the code and reason it arrives with, so both sides must
+ * agree on the exact strings. A silent typo here reclassifies a clean
+ * leave as an unexpected drop (a 30s ghost in the room), which is why
+ * these are constants rather than literals at each site.
+ */
+export const CloseReason = {
+  /** The member chose to leave — no grace period. */
+  UserLeft: 'User left room',
+  /** The admin removed them; the room was already told. */
+  RemovedByAdmin: 'Removed by admin',
+} as const
+
+export type CloseReason = (typeof CloseReason)[keyof typeof CloseReason]
+
+export const CloseCode = {
+  Unknown: 4000,
+  /** The username is already taken in this room; the client must not retry. */
+  UsernameTaken: 4001,
+} as const
+
+export type CloseCode = (typeof CloseCode)[keyof typeof CloseCode]
+
 // ── Client → Server messages ──
 
 export type SubmitVoteMessage = {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -104,7 +104,19 @@ export function isParticipantRole(value: string): value is ParticipantRole {
   return (participantRoles as readonly string[]).includes(value)
 }
 
+/**
+ * Room ids are case- and whitespace-insensitive: `Sprint42` and
+ * `sprint42 ` name the same room. Every entry point normalizes through
+ * here — the HTTP existence probe and the socket upgrade must agree, or a
+ * room can exist under one spelling while the probe reports it missing
+ * under another, and two people "in the same room" never meet.
+ */
+export function normalizeRoomId(raw: string): string {
+  return raw.trim().toLowerCase()
+}
+
 export type WebSocketData = {
+  /** Always normalized — see {@link normalizeRoomId}. */
   roomId: string
   username: string
   /** Deck chosen at creation — only meaningful for the room creator's connection. */


### PR DESCRIPTION
The room lifecycle lived inline in the `Bun.serve` callbacks — a four-way policy branch keyed off close-frame strings, an undocumented ordering constraint, and two verbatim copies of "remove and announce". None of it reachable by a test, because opening the module opened a socket. It was the largest untested surface in the backend and the part with the most cross-module invariants.

This extracts it behind a seam, then fixes two bugs that became visible once it had one.

## Commits

Each is a complete, green state — reviewable and revertable on its own.

| | |
|---|---|
| `d24af3f` | **feat:** give room membership a home |
| `389d1a7` | **fix:** close the room when an absent admin's grace period expires |
| `4a4b196` | **fix:** normalize room ids at every entry point |
| `a5841d4` | **test:** drive the real server over HTTP and WebSockets |

## The seam

`backend/src/roomMembership.ts` — three names over the room roster, the connection registry and the disconnect registry:

```ts
createRoomMembership({ roomManager, connectionManager, disconnectManager, broadcaster })
  → { arrive, depart, evict }
```

`index.ts` drops from 176 to 84 lines and holds no policy. Departure classification moves behind the seam; it reads room state as well as the close frame, because an admin's departure closes the room whatever reason their client sent — so `adminLeft` is checked *before* the reason strings, and that order is asserted.

## Behaviour changes

Three, all deliberate:

- **Evicting an absent member now tells the room immediately.** Previously it broadcast nothing and the room found out up to 30s later via `userLeft` — the wrong message for a removal. `evict` cancels the pending grace entry, so that delayed announcement would never have arrived at all.
- **An absent admin's grace period expiring now closes the room.** `transferAdmin` accepts a member who is in the grace period, so the role can land on someone absent. When their grace expired the room was deleted and the remaining members were told *nothing* — left sitting in a dead room with no `roomClosed`. This bug predates the extraction; it was reachable in the original `index.ts` too.
- **Room ids are normalized at every entry point.** The probe lowercased, the socket upgrade didn't. Reproducible today via the seed script: `bun run seed Sprint42` creates a room a browser at `/room/Sprint42` never joins.

## Testing

164 backend (was 141), 29 frontend, type-check and lint clean.

- `roomMembership.ts` at 100% line and function coverage.
- **`index.ts` from 0% to 96.9%** — the one uncovered line is the upgrade-failure path, which needs Bun internals to trigger.
- `DisconnectManager` takes an injectable scheduler, so grace-period expiry is asserted by advancing a clock. Every `await sleep()` is gone from its suite.
- Eviction tests moved from `clientMessageHandler.test.ts` to `roomMembership.test.ts` — replace, don't layer. The handler keeps a delegation assertion and the throw-becomes-error-reply case.

## Notes for review

- `CloseReason` and `CloseCode` move to `shared/types.ts`. Both sides matched the same literals by hand across four sites; a typo on either would silently reclassify a departure.
- A planned fifth change — extracting the HTTP probe behind its own module — was **dropped on inspection**. It wouldn't have earned the seam: delete the module and complexity moves back to `index.ts` rather than concentrating. What was missing was a test surface, not a module, hence `a5841d4`.
- `CONTEXT.md` gains **Room id**, **Membership**, **Presence**, **Grace period** and **Departure reason**.
- `index.ts` now exports its server handle so the integration suite can bind `PORT=0` and stop it; production still runs `bun index.ts`.

Still open from the review that produced this work, and larger than anything here: the inbound wire contract has no runtime validation (`JSON.parse` cast to `ClientMessage`), and the frontend's 18-case message switch in `useRoomSession.ts` remains untested.