### PR TITLE
Validate the inbound contract at the door

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,6 +81,38 @@ contract (`CloseReason`, `CloseCode` in `shared/types.ts`) — both the
 frontend and the backend import them rather than repeating literals,
 because a typo would silently reclassify a departure.
 
+## Inbound contract
+
+What a client is allowed to send. Every message crosses one seam,
+`parseClientMessage` (`backend/src/clientMessageParser.ts`), which either
+yields a `ClientMessage` or a reason it was refused — nothing downstream
+re-checks shape.
+
+The split is what the door can answer alone:
+
+| Checked at the door                 | Checked in the domain                    |
+| ----------------------------------- | ---------------------------------------- |
+| valid JSON, object, known `type`    | is this card in **this room's** deck      |
+| field present and the right type    | is this member the admin                  |
+| value in a closed set (deck, emoji) | are votes locked; is the target a member  |
+
+Closed-set membership belongs to the door because it needs no room
+state, which is why `ChangeDeckMessage.data.deck` is a `DeckId` and not a
+string: by the time anything sees the message, it has been proven. A
+vote stays a plain string — only the room knows its deck.
+
+Messages are **rebuilt**, not passed through, so unknown fields are
+dropped rather than refused; a newer client stays compatible with an
+older backend. Refusals name the offending field, because the contract is
+public — it ships in the frontend bundle — so there is nothing to
+withhold and a misbehaving client should be diagnosable.
+
+Validation is hand-written guards, not a schema library: ten message
+types, most with a single field, against a backend that otherwise ships
+**zero runtime dependencies**. Worth reconsidering if the message set
+outgrows what is comfortable to hand-check, or if a message ever needs
+nested or conditional structure.
+
 ## Snapshot
 
 The authoritative view of a room a client receives on join or reconnect

--- a/backend/src/__tests__/clientMessageHandler.test.ts
+++ b/backend/src/__tests__/clientMessageHandler.test.ts
@@ -318,13 +318,20 @@ describe("clientMessageHandler", () => {
       expect(roomManager.voteSnapshot("room1").get("voter")).toBe("?");
     });
 
-    test("an unknown deck id is refused", () => {
-      const { calls, send, admin } = setup();
+    test("an unknown deck id never reaches the room", () => {
+      // The rejection itself is clientMessageParser's; what matters here
+      // is that a refused message changes nothing and answers the sender.
+      const { roomManager, calls, send, admin } = setup();
 
-      send(admin, { type: "changeDeck", data: { deck: "tarot" } });
+      send(admin, JSON.stringify({ type: "changeDeck", data: { deck: "tarot" } }));
 
+      expect(roomManager.getRoomDeck("room1")).toBe("fibonacci");
       expect(calls).toEqual([
-        { to: "reply", ws: admin, msg: { type: "error", data: { message: "Invalid deck" } } },
+        {
+          to: "reply",
+          ws: admin,
+          msg: { type: "error", data: { message: "changeDeck requires a known deck" } },
+        },
       ]);
     });
   });
@@ -341,16 +348,6 @@ describe("clientMessageHandler", () => {
           roomId: "room1",
           msg: { type: "reaction", data: { username: "voter", emoji: "🎉" } },
         },
-      ]);
-    });
-
-    test("an emoji outside the allowlist is refused", () => {
-      const { calls, send, voter } = setup();
-
-      send(voter, JSON.stringify({ type: "sendReaction", data: { emoji: "🔥" } }));
-
-      expect(calls).toEqual([
-        { to: "reply", ws: voter, msg: { type: "error", data: { message: "Invalid reaction" } } },
       ]);
     });
 
@@ -389,12 +386,18 @@ describe("clientMessageHandler", () => {
       ]);
     });
 
-    test("a missing participant is ignored, not dispatched", () => {
+    test("an empty participant is answered, not silently dropped", () => {
       const { calls, send, admin } = setup();
 
-      send(admin, { type: "removeParticipant", data: { participant: "" } });
+      send(admin, JSON.stringify({ type: "removeParticipant", data: { participant: "" } }));
 
-      expect(calls).toEqual([]);
+      expect(calls).toEqual([
+        {
+          to: "reply",
+          ws: admin,
+          msg: { type: "error", data: { message: "removeParticipant requires a participant" } },
+        },
+      ]);
     });
 
     test("non-admin removal is refused", () => {

--- a/backend/src/__tests__/clientMessageParser.test.ts
+++ b/backend/src/__tests__/clientMessageParser.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { parseClientMessage } from "../clientMessageParser";
+
+/** The parsed message, or a failure if the payload was rejected. */
+function accepted(raw: unknown) {
+  const result = parseClientMessage(typeof raw === "string" ? raw : JSON.stringify(raw));
+  if (!result.ok) throw new Error(`Expected acceptance, got: ${result.reason}`);
+  return result.message;
+}
+
+function rejection(raw: unknown): string {
+  const result = parseClientMessage(typeof raw === "string" ? raw : JSON.stringify(raw));
+  if (result.ok) throw new Error(`Expected rejection, got: ${JSON.stringify(result.message)}`);
+  return result.reason;
+}
+
+describe("parseClientMessage", () => {
+  describe("payload shape", () => {
+    test("rejects malformed JSON", () => {
+      expect(rejection("not json {")).toBe("Invalid message format. Please send valid JSON.");
+    });
+
+    test.each([
+      ["a bare string", '"just a string"'],
+      ["an array", "[1,2,3]"],
+      ["null", "null"],
+      ["a number", "42"],
+    ])("rejects %s as a message", (_label, raw) => {
+      expect(rejection(raw)).toBe("Unknown message type");
+    });
+
+    test.each([
+      ["an unknown type", { type: "teleport" }],
+      ["a non-string type", { type: 123 }],
+      ["a missing type", { data: { vote: "5" } }],
+    ])("rejects %s", (_label, payload) => {
+      expect(rejection(payload)).toBe("Unknown message type");
+    });
+  });
+
+  describe("commands without a payload", () => {
+    test.each(["revealVotes", "hideVotes", "clearVotes", "lockVotes", "unlockVotes"])(
+      "accepts %s",
+      (type) => {
+        expect(accepted({ type })).toEqual({ type } as never);
+      },
+    );
+
+    test("ignores any data such a command carries", () => {
+      expect(accepted({ type: "revealVotes", data: { nonsense: true } })).toEqual({
+        type: "revealVotes",
+      });
+    });
+  });
+
+  describe("submitVote", () => {
+    test("accepts a string vote", () => {
+      expect(accepted({ type: "submitVote", data: { vote: "5" } })).toEqual({
+        type: "submitVote",
+        data: { vote: "5" },
+      });
+    });
+
+    test("accepts an empty data object as a retraction", () => {
+      // What the frontend actually sends to clear a vote: `vote` is
+      // undefined, so JSON.stringify drops the key entirely.
+      expect(accepted({ type: "submitVote", data: {} })).toEqual({
+        type: "submitVote",
+        data: {},
+      });
+    });
+
+    test("rejects a missing data object", () => {
+      expect(rejection({ type: "submitVote" })).toBe("submitVote requires a data object");
+    });
+
+    test.each([
+      ["an object", { toString: 1 }],
+      ["a number", 5],
+      ["null", null],
+    ])("rejects %s as a vote", (_label, vote) => {
+      expect(rejection({ type: "submitVote", data: { vote } })).toBe(
+        "submitVote requires a string vote",
+      );
+    });
+
+    test("does not validate the vote against the deck — that needs room state", () => {
+      // The door lets an off-deck card through; RoomManager rejects it.
+      expect(accepted({ type: "submitVote", data: { vote: "not-a-card" } })).toEqual({
+        type: "submitVote",
+        data: { vote: "not-a-card" },
+      });
+    });
+  });
+
+  describe("sendReaction", () => {
+    test("accepts a known reaction", () => {
+      expect(accepted({ type: "sendReaction", data: { emoji: "👍" } })).toEqual({
+        type: "sendReaction",
+        data: { emoji: "👍" },
+      });
+    });
+
+    test.each([
+      ["an emoji outside the allowlist", "🔥"],
+      ["a non-emoji string", "hello"],
+      ["a number", 1],
+      ["nothing", undefined],
+    ])("rejects %s", (_label, emoji) => {
+      expect(rejection({ type: "sendReaction", data: { emoji } })).toBe(
+        "sendReaction requires a known reaction",
+      );
+    });
+
+    test("rejects a missing data object", () => {
+      expect(rejection({ type: "sendReaction" })).toBe("sendReaction requires a known reaction");
+    });
+  });
+
+  describe("changeDeck", () => {
+    test("accepts a known deck id", () => {
+      expect(accepted({ type: "changeDeck", data: { deck: "tshirt" } })).toEqual({
+        type: "changeDeck",
+        data: { deck: "tshirt" },
+      });
+    });
+
+    test.each([
+      ["an unknown deck", "tarot"],
+      ["a number", 3],
+      ["nothing", undefined],
+    ])("rejects %s", (_label, deck) => {
+      expect(rejection({ type: "changeDeck", data: { deck } })).toBe(
+        "changeDeck requires a known deck",
+      );
+    });
+  });
+
+  describe("transferAdmin", () => {
+    test("accepts a username", () => {
+      expect(accepted({ type: "transferAdmin", data: { newAdmin: "alice" } })).toEqual({
+        type: "transferAdmin",
+        data: { newAdmin: "alice" },
+      });
+    });
+
+    test.each([
+      ["an empty string", ""],
+      ["an object", { a: 1 }],
+      ["nothing", undefined],
+    ])("rejects %s as newAdmin", (_label, newAdmin) => {
+      expect(rejection({ type: "transferAdmin", data: { newAdmin } })).toBe(
+        "transferAdmin requires a newAdmin",
+      );
+    });
+  });
+
+  describe("removeParticipant", () => {
+    test("accepts a username", () => {
+      expect(accepted({ type: "removeParticipant", data: { participant: "bob" } })).toEqual({
+        type: "removeParticipant",
+        data: { participant: "bob" },
+      });
+    });
+
+    test.each([
+      ["an empty string", ""],
+      ["an object", { a: 1 }],
+      ["nothing", undefined],
+    ])("rejects %s as participant", (_label, participant) => {
+      expect(rejection({ type: "removeParticipant", data: { participant } })).toBe(
+        "removeParticipant requires a participant",
+      );
+    });
+  });
+
+  describe("rebuilding", () => {
+    test("drops unknown fields rather than rejecting the message", () => {
+      // Additive tolerance: a newer client can send a field this backend
+      // does not know about without being refused outright.
+      expect(accepted({ type: "submitVote", data: { vote: "5", futureField: true } })).toEqual({
+        type: "submitVote",
+        data: { vote: "5" },
+      });
+    });
+
+    test("does not carry a prototype-polluting key through", () => {
+      const parsed = accepted('{"type":"transferAdmin","data":{"newAdmin":"alice","__proto__":{"x":1}}}');
+
+      expect(parsed).toEqual({ type: "transferAdmin", data: { newAdmin: "alice" } });
+      expect(Object.keys((parsed as { data: object }).data)).toEqual(["newAdmin"]);
+    });
+  });
+});

--- a/backend/src/clientMessageHandler.ts
+++ b/backend/src/clientMessageHandler.ts
@@ -1,14 +1,10 @@
 import type { ServerWebSocket } from "bun";
-import {
-  isDeckId,
-  isReactionEmoji,
-  type ClientMessage,
-  type WebSocketData,
-} from "@shared/types";
+import type { ClientMessage, WebSocketData } from "@shared/types";
 import type { RoomManager } from "./roomManager";
 import type { RoomBroadcaster } from "./roomBroadcaster";
 import type { ReactionRateLimiter } from "./reactionRateLimiter";
 import type { RoomMembership } from "./roomMembership";
+import { parseClientMessage } from "./clientMessageParser";
 import { userVotedMessage, voteStatusMessage } from "./roomSnapshots";
 import { logger } from "./logger";
 
@@ -22,21 +18,18 @@ export type ClientMessageHandlerDeps = {
 };
 
 /**
- * The room's inbound seam: `handle(ws, raw)` owns parsing, dispatch, and
- * the error path — it never throws. Every outcome is a state change on
- * the RoomManager paired with a broadcast, so tests drive raw messages
- * in and assert recorded broadcasts out.
+ * Dispatch for validated client messages: `handle(ws, raw)` parses,
+ * dispatches, and owns the error path — it never throws. Every outcome is
+ * a state change on the RoomManager paired with a broadcast, so tests
+ * drive raw messages in and assert recorded broadcasts out.
+ *
+ * Shape validation happens in `clientMessageParser`, so `dispatch` reads
+ * message fields without guarding them. What still throws here is the
+ * domain rejecting an action — not a member, not the admin, votes locked
+ * — and those messages are meant for the user.
  */
 export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
   const { roomManager, broadcaster, rateLimiter, membership } = deps;
-
-  function parseMessage(raw: string): ClientMessage {
-    try {
-      return JSON.parse(raw);
-    } catch {
-      throw new Error("Invalid message format. Please send valid JSON.");
-    }
-  }
 
   // Personalized per member: a snapshot carries the recipient's own vote
   // unmasked, so it can't be one shared broadcast. Reveal and hide take
@@ -55,8 +48,7 @@ export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
         break;
 
       case "sendReaction": {
-        const emoji = msg.data?.emoji;
-        if (!isReactionEmoji(emoji)) throw new Error("Invalid reaction");
+        const { emoji } = msg.data;
 
         const rateLimit = rateLimiter.consume(ws);
         if (!rateLimit.allowed) {
@@ -112,8 +104,6 @@ export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
         break;
 
       case "changeDeck": {
-        if (!isDeckId(msg.data.deck)) throw new Error("Invalid deck");
-
         // The room audience includes the admin who changed it — one
         // receive path for everyone. A same-deck call is a no-op so an
         // accidental confirm can't wipe votes.
@@ -125,34 +115,37 @@ export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
       }
 
       case "removeParticipant": {
-        const participantToRemove = msg.data.participant;
-        if (!participantToRemove) break;
-
         // Removal is a membership transition: it touches the roster, the
         // connection registry and any pending grace entry, so it lives
         // behind that seam. Authorization failures throw through to the
         // error reply below.
-        membership.evict(roomId, username, participantToRemove);
+        membership.evict(roomId, username, msg.data.participant);
         break;
       }
 
-      default:
-        broadcaster.reply(ws, { type: "error", data: { message: "Unknown message type" } });
+      default: {
+        // The parser only emits known types, so this is unreachable — but
+        // it makes the compiler flag a new message type that nobody handled.
+        const unhandled: never = msg;
+        throw new Error(`Unhandled message type: ${JSON.stringify(unhandled)}`);
+      }
     }
   }
 
-  function handle(ws: Socket, raw: string): void {
+  function replyError(ws: Socket, raw: string, message: string): void {
     const { roomId, username } = ws.data;
+    logger.warn(`Rejected client message`, { roomId, username, message: raw, error: message });
+    broadcaster.reply(ws, { type: "error", data: { message } });
+  }
+
+  function handle(ws: Socket, raw: string): void {
+    const parsed = parseClientMessage(raw);
+    if (!parsed.ok) return replyError(ws, raw, parsed.reason);
+
     try {
-      dispatch(ws, parseMessage(raw));
+      dispatch(ws, parsed.message);
     } catch (error) {
-      logger.warn(`Error parsing message`, {
-        roomId,
-        username,
-        message: raw,
-        error: (error as Error).message,
-      });
-      broadcaster.reply(ws, { type: "error", data: { message: (error as Error).message } });
+      replyError(ws, raw, (error as Error).message);
     }
   }
 

--- a/backend/src/clientMessageParser.ts
+++ b/backend/src/clientMessageParser.ts
@@ -1,0 +1,103 @@
+import { isDeckId, isReactionEmoji, type ClientMessage } from "@shared/types";
+
+export type ParseResult =
+  | { ok: true; message: ClientMessage }
+  | { ok: false; reason: string };
+
+/**
+ * The inbound seam. Everything arriving from a client passes through
+ * here, and nothing downstream re-checks: `dispatch` may read
+ * `msg.data.newAdmin` without guarding, because a message that reached it
+ * has already been proven to have one.
+ *
+ * The door checks structure and values drawn from a closed set — a known
+ * deck id, a known reaction, a non-empty name. It cannot check anything
+ * that depends on room state (is this card in *this* room's deck? is this
+ * member the admin?); those stay in the RoomManager, which is the only
+ * thing that knows.
+ *
+ * Messages are rebuilt rather than passed through, so what flows on is
+ * exactly the declared shape. Unknown fields are dropped, not rejected —
+ * a newer client can add one without an older backend refusing it.
+ */
+export function parseClientMessage(raw: string): ParseResult {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return invalid("Invalid message format. Please send valid JSON.");
+  }
+
+  if (!isRecord(payload)) return invalid("Unknown message type");
+
+  // Absent or non-object `data` reads as "no fields supplied"; each case
+  // decides whether that is acceptable.
+  const data = isRecord(payload.data) ? payload.data : undefined;
+
+  switch (payload.type) {
+    // Commands with no payload. Any `data` they carry is ignored.
+    case "revealVotes":
+    case "hideVotes":
+    case "clearVotes":
+    case "lockVotes":
+    case "unlockVotes":
+      return valid({ type: payload.type });
+
+    case "submitVote": {
+      if (!data) return invalid("submitVote requires a data object");
+
+      const vote = data.vote;
+      if (vote === undefined) return valid({ type: "submitVote", data: {} });
+      if (typeof vote !== "string") return invalid("submitVote requires a string vote");
+
+      return valid({ type: "submitVote", data: { vote } });
+    }
+
+    case "sendReaction": {
+      const emoji = data?.emoji;
+      if (!isReactionEmoji(emoji)) return invalid("sendReaction requires a known reaction");
+
+      return valid({ type: "sendReaction", data: { emoji } });
+    }
+
+    case "changeDeck": {
+      const deck = data?.deck;
+      if (typeof deck !== "string" || !isDeckId(deck)) {
+        return invalid("changeDeck requires a known deck");
+      }
+
+      return valid({ type: "changeDeck", data: { deck } });
+    }
+
+    case "transferAdmin": {
+      const newAdmin = data?.newAdmin;
+      if (!isNonEmptyString(newAdmin)) return invalid("transferAdmin requires a newAdmin");
+
+      return valid({ type: "transferAdmin", data: { newAdmin } });
+    }
+
+    case "removeParticipant": {
+      const participant = data?.participant;
+      if (!isNonEmptyString(participant)) {
+        return invalid("removeParticipant requires a participant");
+      }
+
+      return valid({ type: "removeParticipant", data: { participant } });
+    }
+
+    default:
+      return invalid("Unknown message type");
+  }
+}
+
+const valid = (message: ClientMessage): ParseResult => ({ ok: true, message });
+const invalid = (reason: string): ParseResult => ({ ok: false, reason });
+
+/** Arrays and null are not message shapes, however `typeof` sees them. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -152,9 +152,17 @@ export const CloseCode = {
 export type CloseCode = (typeof CloseCode)[keyof typeof CloseCode]
 
 // ── Client → Server messages ──
+//
+// These describe messages that have already been validated at the
+// backend's inbound seam (`clientMessageParser`). Values drawn from a
+// closed set are typed as that set, because the door checks membership
+// before anything downstream sees the message. `vote` stays a plain
+// string: whether a card belongs to the room's deck depends on room
+// state, so only the domain can answer it.
 
 export type SubmitVoteMessage = {
   type: 'submitVote'
+  /** An absent `vote` retracts: `{"type":"submitVote","data":{}}`. */
   data: { vote?: string }
 }
 
@@ -190,7 +198,7 @@ export type RemoveParticipantMessage = {
 
 export type ChangeDeckMessage = {
   type: 'changeDeck'
-  data: { deck: string }
+  data: { deck: DeckId }
 }
 
 export type SendReactionMessage = {


### PR DESCRIPTION
`parseMessage` was `JSON.parse` with a return type annotation. The `ClientMessage` union was a compile-time fiction on the inbound path — nothing had checked it — so each branch of `dispatch` decided for itself how paranoid to be, and four of five chose not to be at all. Only `sendReaction` guarded, with `msg.data?.emoji`. That asymmetry is the signature of a missing seam.

## What reached the client

Verified against the real handler before the change:

| Payload | Reply, verbatim |
|---|---|
| `{"type":"submitVote"}` | `undefined is not an object (evaluating 'msg.data.vote')` |
| `{"type":"transferAdmin"}` | `undefined is not an object (evaluating 'msg.data.newAdmin')` |
| `{"type":"changeDeck"}` | `undefined is not an object (evaluating 'msg.data.deck')` |
| `{"type":"removeParticipant"}` | `undefined is not an object (evaluating 'msg.data.participant')` |
| `null` | `null is not an object (evaluating 'msg.type')` |

Each is now a designed rejection naming the offending field.

## The seam

`backend/src/clientMessageParser.ts`, one entry point:

```ts
export function parseClientMessage(raw: string): ParseResult
// { ok: true; message: ClientMessage } | { ok: false; reason: string }
```

Rejection is an expected outcome of untrusted input, not an exception — and the tagged union makes the seam visible in the type, since the message can't be reached without narrowing first.

**The door checks what it can answer alone:** structure, field types, and membership of a closed set. **Contextual rules stay in the domain**, which is the only thing that knows them — whether a card belongs to *this room's* deck, whether this member is the admin. So `dispatch` drops `isDeckId`, `isReactionEmoji` and the empty-participant guard, and reads its input without guarding.

## The types stop lying

- `ChangeDeckMessage.data.deck` → `DeckId` (was `string`)
- `SendReactionMessage.data.emoji: ReactionEmoji` — was an assertion about unvalidated input, now true
- `SubmitVoteMessage.data.vote?: string` — unchanged, deliberately; deck-validity is contextual

Messages are **rebuilt** rather than passed through, so unknown fields are dropped instead of refused — a newer client stays compatible with an older backend — and no unexpected key rides along. There's a test for the `__proto__` case.

## Behaviour changes

1. An empty `participant` used to `break` silently, sending **no reply at all**. It's now answered.
2. `Invalid deck` / `Invalid reaction` become messages that name the field. The frontend toasts these verbatim, so they're user-visible.

## Testing

204 backend (was 164), 29 frontend, type-check and lint clean.

- `clientMessageParser.ts` at **100%** line and function coverage.
- Hostile input moved to `clientMessageParser.test.ts`; the handler suite keeps valid input plus one case proving a rejection reaches the sender and changes nothing — replace, don't layer.
- The handler's only uncovered lines are a new `default:` exhaustiveness branch, unreachable by design but there so the compiler flags an unhandled message type.

## Notes

- **No new dependency.** Hand-written guards extend the idiom `shared/types.ts` already uses, against a backend that otherwise ships zero runtime deps. `CONTEXT.md` records when to reconsider a schema library: if the message set outgrows hand-checking, or a message needs nested or conditional structure.
- Domain errors still reach the client unchanged — `Only the admin can clear votes` is meant for the user. Sanitizing genuine bugs behind a `DomainError` class was considered and left out; it would touch ~22 throw sites in `RoomManager` for a path that validation now makes unreachable.
- `CONTEXT.md` gains an **Inbound contract** term with the door/domain table.

**Still open**, and the last Strong item from the review that started this: the frontend's mirror cast at `roomConnection.ts:110`, and the untested 18-case message switch in `useRoomSession.ts`.