### PR TITLE
Normalize room action sender echoes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -152,7 +152,16 @@ and hide, so the audience isn't re-decided case by case.
 
 **Actor**: the member whose client message triggered the broadcast.
 
-The actor-exclusion on `votesCleared` is deliberate: the actor's client
-applies the clear locally and stays silent (no new-round sound cue for
-one's own clear). Whether to normalize this asymmetry so every action
-echoes to its actor is an open question tracked in the issue tracker.
+Room actions handled from authenticated client messages use the **room**
+audience, so every member follows one receive path. The frontend
+explicitly gates the two optimistic actions when their echoes return:
+`userVoted` already names its actor, and `votesCleared` carries
+`clearedBy`. A client keeps its own unmasked optimistic vote instead of
+adopting the hidden room payload, and an admin acknowledges its own clear
+without replaying the reset or new-round cue. Clears by another admin
+still apply the reset and play the cue.
+
+`toRoomExcept` remains for membership arrivals (`userJoined` and
+`userReconnected`): the arriving member gets an authoritative
+[Snapshot](#snapshot) reply instead of consuming its own presence
+announcement.

--- a/backend/src/__tests__/clientMessageHandler.test.ts
+++ b/backend/src/__tests__/clientMessageHandler.test.ts
@@ -56,7 +56,7 @@ function setup() {
 
 describe("clientMessageHandler", () => {
   describe("submitVote", () => {
-    test("records the vote and broadcasts it masked while votes are hidden", () => {
+    test("records the vote and broadcasts it masked to the whole room while votes are hidden", () => {
       const { roomManager, calls, send, voter } = setup();
 
       send(voter, { type: "submitVote", data: { vote: "5" } });
@@ -64,22 +64,22 @@ describe("clientMessageHandler", () => {
       expect(roomManager.voteSnapshot("room1").get("voter")).toBe("?");
       expect(calls).toEqual([
         {
-          to: "roomExcept",
-          sender: voter,
+          to: "room",
+          roomId: "room1",
           msg: { type: "userVoted", data: { username: "voter", vote: "?" } },
         },
       ]);
     });
 
-    test("broadcasts the real vote once votes are revealed", () => {
+    test("broadcasts the real vote to the whole room once votes are revealed", () => {
       const { calls, send, admin, voter } = setup();
 
       send(admin, { type: "revealVotes" });
       send(voter, { type: "submitVote", data: { vote: "8" } });
 
       expect(calls.at(-1)).toEqual({
-        to: "roomExcept",
-        sender: voter,
+        to: "room",
+        roomId: "room1",
         msg: { type: "userVoted", data: { username: "voter", vote: "8" } },
       });
     });
@@ -213,7 +213,7 @@ describe("clientMessageHandler", () => {
   });
 
   describe("clearVotes", () => {
-    test("clears state and notifies everyone except the acting admin", () => {
+    test("clears state and notifies the whole room who acted", () => {
       const { roomManager, calls, send, admin, voter } = setup();
 
       send(voter, { type: "submitVote", data: { vote: "5" } });
@@ -222,11 +222,10 @@ describe("clientMessageHandler", () => {
 
       expect(roomManager.voteSnapshot("room1").get("voter")).toBeNull();
       expect(roomManager.getRoomVisibility("room1")).toBe(false);
-      // The actor is deliberately excluded: their client clears locally.
       expect(calls.at(-1)).toEqual({
-        to: "roomExcept",
-        sender: admin,
-        msg: { type: "votesCleared" },
+        to: "room",
+        roomId: "room1",
+        msg: { type: "votesCleared", data: { clearedBy: "admin" } },
       });
     });
 

--- a/backend/src/__tests__/roomBroadcaster.test.ts
+++ b/backend/src/__tests__/roomBroadcaster.test.ts
@@ -49,12 +49,18 @@ describe("BunRoomBroadcaster", () => {
     const { broadcaster, published } = setup();
     const sender = fakeSocket("room1", "admin");
 
-    broadcaster.toRoomExcept(sender, { type: "votesCleared" });
+    broadcaster.toRoomExcept(sender, {
+      type: "votesCleared",
+      data: { clearedBy: "admin" },
+    });
 
     // ws.publish excludes the sender's own subscription — that transport
     // behavior is what makes this the "room except actor" audience.
     expect(sender.published).toEqual([
-      { topic: "room1", raw: JSON.stringify({ type: "votesCleared" }) },
+      {
+        topic: "room1",
+        raw: JSON.stringify({ type: "votesCleared", data: { clearedBy: "admin" } }),
+      },
     ]);
     expect(published).toEqual([]);
   });
@@ -78,7 +84,10 @@ describe("BunRoomBroadcaster", () => {
     const { broadcaster } = setup();
 
     expect(() =>
-      broadcaster.toUser("room1", "ghost", { type: "votesCleared" }),
+      broadcaster.toUser("room1", "ghost", {
+        type: "votesCleared",
+        data: { clearedBy: "admin" },
+      }),
     ).not.toThrow();
   });
 
@@ -105,7 +114,10 @@ describe("BunRoomBroadcaster", () => {
   test("toEachMember reaches nobody in an empty room", () => {
     const { broadcaster, published } = setup();
 
-    broadcaster.toEachMember("ghost-room", () => ({ type: "votesCleared" }));
+    broadcaster.toEachMember("ghost-room", () => ({
+      type: "votesCleared",
+      data: { clearedBy: "admin" },
+    }));
 
     expect(published).toEqual([]);
   });

--- a/backend/src/clientMessageHandler.ts
+++ b/backend/src/clientMessageHandler.ts
@@ -44,7 +44,7 @@ export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
     switch (msg.type) {
       case "submitVote":
         roomManager.submitVote(roomId, username, msg.data.vote ?? null);
-        broadcaster.toRoomExcept(ws, userVotedMessage(roomId, username, roomManager));
+        broadcaster.toRoom(roomId, userVotedMessage(roomId, username, roomManager));
         break;
 
       case "sendReaction": {
@@ -80,9 +80,7 @@ export function createClientMessageHandler(deps: ClientMessageHandlerDeps) {
       case "clearVotes":
         roomManager.clearVotes(roomId, username);
         roomManager.setVoteVisibility(roomId, username, false);
-        // Deliberately excludes the actor: the admin's client clears
-        // locally and stays silent (no new-round cue for one's own clear).
-        broadcaster.toRoomExcept(ws, { type: "votesCleared" });
+        broadcaster.toRoom(roomId, { type: "votesCleared", data: { clearedBy: username } });
         break;
 
       case "transferAdmin":

--- a/frontend/src/composables/__tests__/useRoomSession.test.ts
+++ b/frontend/src/composables/__tests__/useRoomSession.test.ts
@@ -1,0 +1,159 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { FakeSocket } from "@/testing/fakeSocket";
+
+const { route, router, toast } = vi.hoisted(() => ({
+  route: { query: {} as Record<string, string> },
+  router: {
+    push: vi.fn(),
+    replace: vi.fn(),
+  },
+  toast: { add: vi.fn() },
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => route,
+  useRouter: () => router,
+}));
+
+vi.mock("primevue/usetoast", () => ({
+  useToast: () => toast,
+}));
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const audioStarts: number[] = [];
+
+class FakeAudioContext {
+  currentTime = 0;
+  destination = {};
+  state = "running";
+}
+
+class FakeOscillatorNode {
+  constructor(_context: FakeAudioContext, _options: { type: string; frequency: number }) {}
+
+  connect(node: unknown) {
+    return node as FakeGainNode;
+  }
+
+  start(time: number) {
+    audioStarts.push(time);
+  }
+
+  stop() {}
+}
+
+class FakeGainNode {
+  gain = {
+    setValueAtTime() {},
+    linearRampToValueAtTime() {},
+    exponentialRampToValueAtTime() {},
+  };
+
+  constructor(_context: FakeAudioContext, _options: { gain: number }) {}
+
+  connect() {
+    return this;
+  }
+}
+
+let useRootStore: typeof import("@/stores/root").useRootStore;
+let useRoomSession: typeof import("../useRoomSession").useRoomSession;
+
+beforeAll(async () => {
+  vi.stubGlobal("localStorage", new MemoryStorage());
+  localStorage.setItem("sound-cues-enabled", "true");
+  vi.stubGlobal("WebSocket", FakeSocket);
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+  vi.stubGlobal("OscillatorNode", FakeOscillatorNode);
+  vi.stubGlobal("GainNode", FakeGainNode);
+  vi.stubEnv("VITE_SOCKET_URL", "ws://localhost:3000");
+  vi.spyOn(performance, "now").mockReturnValue(1_000);
+
+  ({ useRootStore } = await import("@/stores/root"));
+  ({ useRoomSession } = await import("../useRoomSession"));
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem("sound-cues-enabled", "true");
+  FakeSocket.instances = [];
+  audioStarts.length = 0;
+  route.query = {};
+  router.push.mockClear();
+  router.replace.mockClear();
+  toast.add.mockClear();
+  setActivePinia(createPinia());
+});
+
+describe("useRoomSession sender echoes", () => {
+  it("keeps the actor's optimistic vote when its masked broadcast echoes back", () => {
+    const store = useRootStore();
+    store.setUsername("voter");
+    store.addParticipant({ username: "voter" });
+    const session = useRoomSession("room1");
+
+    session.vote("5");
+    FakeSocket.instances.at(-1)!.emitMessage({
+      type: "userVoted",
+      data: { username: "voter", vote: "?" },
+    });
+
+    expect(store.pointEstimate).toBe("5");
+    expect(store.participants.get("voter")).toBe("5");
+  });
+
+  it("acknowledges its own clear silently and cues a clear by another admin", () => {
+    const store = useRootStore();
+    store.setUsername("admin");
+    store.addParticipant({ username: "admin" });
+    const session = useRoomSession("room1");
+    const socket = FakeSocket.instances.at(-1)!;
+
+    session.vote("5");
+    session.startNewRound();
+    socket.emitMessage({
+      type: "votesCleared",
+      data: { clearedBy: "admin" },
+    });
+
+    expect(store.participants.get("admin")).toBeUndefined();
+    expect(audioStarts).toEqual([]);
+
+    session.vote("8");
+    socket.emitMessage({
+      type: "votesCleared",
+      data: { clearedBy: "next-admin" },
+    });
+
+    expect(store.participants.get("admin")).toBeUndefined();
+    expect(audioStarts).toHaveLength(1);
+  });
+});

--- a/frontend/src/composables/useRoomSession.ts
+++ b/frontend/src/composables/useRoomSession.ts
@@ -39,8 +39,8 @@ export function useRoomSession(id: string) {
     deck,
   } = storeToRefs(store);
 
-  // Cues fire only on incoming server messages, so self-initiated new
-  // rounds stay silent (the server doesn't echo votesCleared to the actor).
+  // Cues fire on incoming server messages. The switch below gates the
+  // actor's votesCleared echo so self-initiated rounds stay silent.
   const { soundCuesEnabled, toggleSoundCues, playRevealCue, playNewRoundCue } = useSoundCues();
 
   const connectionStatus = ref<ConnectionStatus>("disconnected");
@@ -201,6 +201,9 @@ export function useRoomSession(id: string) {
         addNotification(`Admin role transferred to ${msg.data.newAdmin}`);
         break;
       case "userVoted":
+        // Our optimistic vote is unmasked; do not replace it with the
+        // masked whole-room echo while the round is hidden.
+        if (msg.data.username === username.value) break;
         store.setParticipantPointEstimate(msg.data.username, msg.data.vote);
         break;
       case "voteStatus":
@@ -210,6 +213,9 @@ export function useRoomSession(id: string) {
         adoptOwnVote();
         break;
       case "votesCleared":
+        // startNewRound already applied our own clear locally. Acknowledge
+        // its echo without replaying the state change or its sound cue.
+        if (msg.data.clearedBy === username.value) break;
         store.clearVotes();
         votesVisible.value = false;
         playNewRoundCue();

--- a/frontend/src/modules/__tests__/roomConnection.test.ts
+++ b/frontend/src/modules/__tests__/roomConnection.test.ts
@@ -4,46 +4,8 @@ import {
   createRoomConnection,
   type ConnectionStatus,
   type RoomConnection,
-  type WebSocketLike,
 } from "../roomConnection";
-
-/**
- * A fake socket the tests drive by hand. It records what was sent/closed
- * and exposes helpers to simulate the events a real WebSocket would fire.
- */
-class FakeSocket implements WebSocketLike {
-  onopen: (() => void) | null = null;
-  onmessage: ((event: { data: unknown }) => void) | null = null;
-  onclose: ((event: { code: number; reason: string }) => void) | null = null;
-  onerror: ((event: unknown) => void) | null = null;
-
-  sent: string[] = [];
-  closedWith: { code?: number; reason?: string } | null = null;
-
-  constructor(readonly url: URL) {}
-
-  send(data: string) {
-    this.sent.push(data);
-  }
-
-  // The connection calls this on disconnect(); a real socket would then
-  // fire onclose asynchronously — tests drive that explicitly via emitClose.
-  close(code?: number, reason?: string) {
-    this.closedWith = { code, reason };
-  }
-
-  emitOpen() {
-    this.onopen?.();
-  }
-
-  emitMessage(msg: unknown) {
-    this.onmessage?.({ data: JSON.stringify(msg) });
-  }
-
-  emitClose(code: number, reason = "") {
-    this.onclose?.({ code, reason });
-  }
-}
+import { FakeSocket } from "@/testing/fakeSocket";
 
 function setup(url = new URL("ws://localhost:3000/?roomId=r&username=u")) {
   const sockets: FakeSocket[] = [];
@@ -94,10 +56,10 @@ describe("createRoomConnection", () => {
     const { latest, statuses, messages } = setup();
 
     latest().emitOpen();
-    latest().emitMessage({ type: "votesCleared" });
+    latest().emitMessage({ type: "votesCleared", data: { clearedBy: "admin" } });
 
     expect(statuses).toEqual(["connected"]);
-    expect(messages).toEqual([{ type: "votesCleared" }]);
+    expect(messages).toEqual([{ type: "votesCleared", data: { clearedBy: "admin" } }]);
   });
 
   describe("senders", () => {

--- a/frontend/src/testing/fakeSocket.ts
+++ b/frontend/src/testing/fakeSocket.ts
@@ -1,0 +1,41 @@
+import type { WebSocketLike } from "@/modules/roomConnection";
+
+/**
+ * Browser WebSocket boundary fake shared by connection and room-session
+ * tests. Tests drive lifecycle events explicitly and inspect sent/close
+ * behavior without replacing any application-owned collaborators.
+ */
+export class FakeSocket implements WebSocketLike {
+  static instances: FakeSocket[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  sent: string[] = [];
+  closedWith: { code?: number; reason?: string } | null = null;
+
+  constructor(readonly url: URL) {
+    FakeSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string) {
+    this.closedWith = { code, reason };
+  }
+
+  emitOpen() {
+    this.onopen?.();
+  }
+
+  emitMessage(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+
+  emitClose(code: number, reason = "") {
+    this.onclose?.({ code, reason });
+  }
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -256,6 +256,7 @@ export type VoteStatusMessage = {
 
 export type VotesClearedMessage = {
   type: 'votesCleared'
+  data: { clearedBy: string }
 }
 
 export type AdminTransferredMessage = {


### PR DESCRIPTION
## Summary

- Broadcast vote submissions and vote clears to the entire room.
- Preserve optimistic local votes when masked echoes return.
- Identify clear actors so self-clears remain silent while other admins trigger reset cues.
- Add shared fake socket coverage and update message types and documentation.

## Testing

- Not run; reviewed the included backend and frontend test updates.